### PR TITLE
Refactor/event property types

### DIFF
--- a/sharedkernel/infrastructure/data.py
+++ b/sharedkernel/infrastructure/data.py
@@ -1,4 +1,6 @@
 from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
 
 
 @dataclass(frozen=True)
@@ -11,20 +13,20 @@ class DataModel:
 
 @dataclass(frozen=True)
 class Event(DataModel):
-    event_id: str
+    event_id: UUID
     event_type: str
     position: int
     data: str
-    stream_id: str
+    stream_id: UUID
     stream_type: str
     version: int
-    created: str
-    correlation_id: str
+    created: datetime
+    correlation_id: UUID
 
 
 @dataclass(frozen=True)
 class Message:
-    message_id: str
+    message_id: UUID
     content_type: str
     subject: str
     body: str

--- a/sharedkernel/infrastructure/mappers.py
+++ b/sharedkernel/infrastructure/mappers.py
@@ -1,9 +1,11 @@
 import json
 from collections import deque
+from datetime import datetime
 from typing import get_args, Generic, TypeVar, Deque, List
 from abc import abstractmethod, ABC
 from types import get_original_bases
 from typing import Dict, Any, Optional, Self
+from uuid import UUID
 
 from sharedkernel.domain.events import DomainEvent
 from sharedkernel.infrastructure.data import Event
@@ -22,17 +24,18 @@ def extract(data: str) -> str:
     return data
 
 
+# noinspection PyUnusedLocal
 def to_event(message: Dict[str, Any], context: Any):
     return Event(
-        event_id=message['id'],
+        event_id=UUID(message['id']),
         event_type=message['type'],
         position=message['position'],
         data=extract(message['data']),
-        stream_id=message['stream_id'],
+        stream_id=UUID(message['stream_id']),
         stream_type=message['stream_type'],
         version=message['version'],
-        created=message['created'],
-        correlation_id=message['correlation_id'],
+        created=datetime.fromisoformat(message['created']),
+        correlation_id=UUID(message['correlation_id']),
     )
 
 

--- a/sharedkernel/infrastructure/services.py
+++ b/sharedkernel/infrastructure/services.py
@@ -155,7 +155,6 @@ class EventDispatcher:
             MapperNotFound
         """
         event_type = event.event_type
-        entity_id = UUID(event.stream_id)
 
         if event_type not in self._listeners:
             self._logger.debug(f"No listener subscribed for {event_type} event")
@@ -172,4 +171,4 @@ class EventDispatcher:
 
         self._logger.info(f"{event_type} event dispatched to all listeners")
         for listener in listener_group:
-            listener.process(domain_event, event.position, entity_id)
+            listener.process(domain_event, event.position, event.stream_id)

--- a/tests/infrastructure/event_dispatcher_test.py
+++ b/tests/infrastructure/event_dispatcher_test.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from datetime import datetime
 from functools import singledispatchmethod
 from uuid import UUID
 
@@ -148,15 +149,15 @@ def test_projector_with_no_handled_event_raise_error(fake_logger):
 def test_event_is_processed_by_subscribed_listener(fake_logger, capture_stdout):
     # Arrange
     event = Event(
-        event_id="018f55de-8321-7efd-a4e3-fcc2c5ec5eea",
+        event_id=UUID("018f55de-8321-7efd-a4e3-fcc2c5ec5eea"),
         event_type="UserRegistered",
         position=1,
         data='{"user_id":"018f9284-769b-726d-b3bf-3885bf2ddd3c",   "name":"John Doe Smith",   "slug":"john-doe-smith"}',
-        stream_id="018f9284-769b-726d-b3bf-3885bf2ddd3c",
+        stream_id=UUID("018f9284-769b-726d-b3bf-3885bf2ddd3c"),
         stream_type="User",
         version=1,
-        created='2024-04-28T12:30−04:00',
-        correlation_id='018fa862-800b-7b6a-8690-ba0e06908c26'
+        created=datetime.fromisoformat('2024-04-28T12:30:12-04:00'),
+        correlation_id=UUID('018fa862-800b-7b6a-8690-ba0e06908c26'),
     )
 
     projection = UserDetailsProjection()
@@ -177,15 +178,15 @@ def test_event_is_processed_by_subscribed_listener(fake_logger, capture_stdout):
 def test_no_event_is_processed_when_no_event_listener(fake_logger, capture_stdout):
     # Arrange
     event = Event(
-        event_id="018f55de-8321-7efd-a4e3-fcc2c5ec5eea",
+        event_id=UUID("018f55de-8321-7efd-a4e3-fcc2c5ec5eea"),
         event_type="UserRegistered",
         position=1,
         data='{"user_id":"018f9284-769b-726d-b3bf-3885bf2ddd3c",   "name":"John Doe Smith",   "slug":"john-doe-smith"}',
-        stream_id="018f9284-769b-726d-b3bf-3885bf2ddd3c",
+        stream_id=UUID("018f9284-769b-726d-b3bf-3885bf2ddd3c"),
         stream_type="User",
         version=1,
-        created='2024-04-28T12:30−04:00',
-        correlation_id='018fa862-800b-7b6a-8690-ba0e06908c26'
+        created=datetime.fromisoformat('2024-04-28T12:30:12-04:00'),
+        correlation_id=UUID('018fa862-800b-7b6a-8690-ba0e06908c26'),
     )
 
     projection = AccountDetailsProjection()
@@ -205,15 +206,15 @@ def test_no_event_is_processed_when_no_event_listener(fake_logger, capture_stdou
 def test_projector_with_no_event_mapper_raise_error(fake_logger):
     # Arrange
     event = Event(
-        event_id="018f55de-8321-7efd-a4e3-fcc2c5ec5eea",
+        event_id=UUID("018f55de-8321-7efd-a4e3-fcc2c5ec5eea"),
         event_type="UserRegistered",
         position=1,
         data='{"user_id":"018f9284-769b-726d-b3bf-3885bf2ddd3c",   "name":"John Doe Smith",   "slug":"john-doe-smith"}',
-        stream_id="018f9284-769b-726d-b3bf-3885bf2ddd3c",
+        stream_id=UUID("018f9284-769b-726d-b3bf-3885bf2ddd3c"),
         stream_type="User",
         version=1,
-        created='2024-04-28T12:30−04:00',
-        correlation_id='018fa862-800b-7b6a-8690-ba0e06908c26'
+        created=datetime.fromisoformat('2024-04-28T12:30:12-04:00'),
+        correlation_id=UUID('018fa862-800b-7b6a-8690-ba0e06908c26'),
     )
 
     projection = UserDetailsProjection()

--- a/tests/infrastructure/mappers_test.py
+++ b/tests/infrastructure/mappers_test.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Dict, Any, Optional
 from uuid import UUID
 
@@ -71,16 +72,16 @@ def test_extract_return_same_json_string():
 def test_deserialize_json_string_to_event():
     # Arrange
     expected = Event(
-        event_id="018ff859-d78c-4dc8-e0d2-4094d208a18c",
+        event_id=UUID("018ff859-d78c-4dc8-e0d2-4094d208a18c"),
         event_type="OfficialNameUpdated",
         position=4,
         data="{\"official_id\": \"018fdb92-75b9-2616-9a6c-720aae66a022\", \"new_name\": \"John Doe IV\", "
              "\"previous_name\": \"John Doe III\"}",
-        stream_id="018fdb92-75b9-2616-9a6c-720aae66a022",
+        stream_id=UUID("018fdb92-75b9-2616-9a6c-720aae66a022"),
         stream_type="Official",
         version=7,
-        created="2024-06-08 14:56:28.542193+00",
-        correlation_id="018ff859-d78b-c284-3284-b7cbd0a31642",
+        created=datetime.fromisoformat("2024-06-08 14:56:28.542193+00"),
+        correlation_id=UUID("018ff859-d78b-c284-3284-b7cbd0a31642"),
     )
 
     obj_dict = {
@@ -131,7 +132,6 @@ def test_mapper_return_none_with_invalid_data():
     mapper = UserRegisteredMapper()
 
     # Act
-
     result = mapper.map(data, event_type)
 
     # Assert


### PR DESCRIPTION
Change event data model properties data type.
Add data type parse in to event function.
Remove event uuid id parsing.
Change projector event generic type to domain event.
