### PR TITLE
fix: Correct type annotations for ReadModelList, Mapper, and RequestMapper

### DIFF
--- a/sharedkernel/api/mappers.py
+++ b/sharedkernel/api/mappers.py
@@ -43,7 +43,7 @@ class RequestMapper[TRequest: Request](ABC):
         """
         ...
 
-    def map_next(self, request: TRequest, **query_params: Any) -> Command | Query | None:
+    def map_next(self, request: TRequest, **query_params: Any) -> Any:
         """Delegates mapping to the next mapper in the chain.
 
         Args:

--- a/sharedkernel/domain/data.py
+++ b/sharedkernel/domain/data.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from dataclasses import dataclass
 
 
@@ -19,9 +20,9 @@ class ReadModelList:
         offset: number of skipped items.
         limit: number of items per page.
         total: total number of items.
-        items: list of `ReadModel` paginated items.
+        items: sequence of `ReadModel` paginated items.
     """
     offset: int
     limit: int
     total: int
-    items: list[ReadModel]
+    items: Sequence[ReadModel]

--- a/sharedkernel/infrastructure/mappers.py
+++ b/sharedkernel/infrastructure/mappers.py
@@ -70,7 +70,7 @@ class Mapper[TEvent: DomainEvent](ABC):
         """
         ...
 
-    def map_next(self, data: dict[str, Any], event_type: str) -> DomainEvent | None:
+    def map_next(self, data: dict[str, Any], event_type: str) -> TEvent | None:
         """Delegates mapping to the next mapper in the chain.
 
         Args:


### PR DESCRIPTION
## Summary

- **ReadModelList.items** (`sharedkernel/domain/data.py`): Change type from `list[ReadModel]` to `Sequence[ReadModel]`. `Sequence` is covariant, so subclasses can assign `Sequence[CoachDetails]` without `# type: ignore[assignment]`.
- **Mapper.map_next()** (`sharedkernel/infrastructure/mappers.py`): Change return type from `DomainEvent | None` to `TEvent | None` so concrete mappers can delegate via `map_next()` without `# type: ignore[return-value]`.
- **RequestMapper.map_next()** (`sharedkernel/api/mappers.py`): Change return type from `Command | Query | None` to `Any` so concrete implementations can narrow their `map()` return type without `# type: ignore[return-value]`.

Closes #110
Closes #111

## Test plan

- [x] `uv run mypy sharedkernel/` — passes with no issues
- [x] `uv run pytest` — 91 tests pass
- [x] `uv run ruff check .` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)