### PR TITLE
Release v6.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Shared Kernel will be documented in this file.
 
+## 6.1.1 (2026-03-15)
+
+### Fixed
+
+- Type annotation for `ReadModelList.items` changed from invariant `list` to covariant `Sequence`.
+- `Mapper.map_next()` return type corrected from `DomainEvent | None` to `TEvent | None`.
+- `RequestMapper.map_next()` return type corrected from `Command | Query | None` to `Any`.
+
 ## 6.1.0 (2026-03-12)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Shared Kernel is built using Python 3.12 and depends on the follow libraries:
 To install Share Kernel using pip, run:
 
 ```shell
-pip install git+https://github.com/juanluiscr27/shared-kernel.git@v6.1.0#egg=sharedkernel
+pip install git+https://github.com/juanluiscr27/shared-kernel.git@v6.1.1#egg=sharedkernel
 ```
 
 ## Usage

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ maintaining clean boundaries.
 ### Installation
 
 ```bash
-pip install git+https://github.com/juanluiscr27/shared-kernel.git@v6.1.0#egg=sharedkernel
+pip install git+https://github.com/juanluiscr27/shared-kernel.git@v6.1.1#egg=sharedkernel
 ```
 
 ### Basic Example: Value Objects

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sharedkernel"
-version = "6.1.0"
+version = "6.1.1"
 description = "Shared Kernel for clean architecture projects"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -428,7 +428,7 @@ wheels = [
 
 [[package]]
 name = "sharedkernel"
-version = "6.1.0"
+version = "6.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Bump version from 6.1.0 to 6.1.1
- Add changelog entry for v6.1.1 with type annotation fixes
- Update install URLs in README.md and docs/index.md

## Changes included in this release
- **fix:** Correct type annotations for `ReadModelList`, `Mapper`, and `RequestMapper` (closes #110, #111)

## Post-merge steps
1. `git tag v6.1.1` on the merge commit
2. `git push origin v6.1.1` — CI will create the GitHub Release automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)