### PR TITLE
fix: Check entity type in equality comparison

### DIFF
--- a/sharedkernel/domain/models.py
+++ b/sharedkernel/domain/models.py
@@ -57,8 +57,9 @@ class Entity[TId: EntityID]:
         return f"{self.__class__.__name__}(id={self._id})"
 
     def __eq__(self, other: object) -> bool:
-        if not isinstance(other, Entity):
+        if type(self) is not type(other):
             return NotImplemented
+        assert isinstance(other, Entity)
         return self._id == other.id
 
     def __ne__(self, other: object) -> bool:

--- a/sharedkernel/domain/models.py
+++ b/sharedkernel/domain/models.py
@@ -57,9 +57,10 @@ class Entity[TId: EntityID]:
         return f"{self.__class__.__name__}(id={self._id})"
 
     def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Entity):
+            return NotImplemented
         if type(self) is not type(other):
             return NotImplemented
-        assert isinstance(other, Entity)
         return self._id == other.id
 
     def __ne__(self, other: object) -> bool:

--- a/tests/domain/models_test.py
+++ b/tests/domain/models_test.py
@@ -26,6 +26,13 @@ class Country(Entity[CountryID]):
         self.name: str = name
 
 
+class City(Entity[CountryID]):
+
+    def __init__(self, city_id: CountryID, name):
+        super().__init__(city_id)
+        self.name: str = name
+
+
 @dataclass(frozen=True)
 class UserID(EntityID):
     value: int
@@ -151,6 +158,30 @@ def test_entities_with_different_id_are_not_equal():
 
     # Assert
     assert country1 != country2
+
+
+def test_entities_of_different_types_with_same_id_are_not_equal():
+    # Arrange
+    shared_id = CountryID("DO")
+
+    # Act
+    country = Country(country_id=shared_id, name="Dominican Republic")
+    city = City(city_id=shared_id, name="Santo Domingo")
+
+    # Assert
+    assert country != city
+
+
+def test_entities_of_different_types_with_same_id_are_not_equal_reversed():
+    # Arrange
+    shared_id = CountryID("DO")
+
+    # Act
+    country = Country(country_id=shared_id, name="Dominican Republic")
+    city = City(city_id=shared_id, name="Santo Domingo")
+
+    # Assert
+    assert city != country
 
 
 def test_entity_not_equal_to_value_object_is_true():


### PR DESCRIPTION
## Summary

- Fixes Entity.__eq__ to use strict type checking (`type(self) is not type(other)`) instead of `isinstance(other, Entity)`, so entities of different types with the same ID are no longer considered equal
- Adds `City` test fixture and two new tests verifying cross-type inequality in both directions

Closes #114

## Test plan

- [x] New tests fail before the fix (confirmed: both `FAILED`)
- [x] All 19 tests in `tests/domain/models_test.py` pass after the fix
- [x] `ruff check` clean
- [x] `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)