### PR TITLE
EventBroker accepts Event and propagates correlation ID

### DIFF
--- a/docs/how-to/messaging.md
+++ b/docs/how-to/messaging.md
@@ -1,10 +1,10 @@
 # How to: Messaging & Event Distribution
 
-The Shared Kernel provides two main mechanisms for event distribution: the **Event Broker** for simple in-memory pub-sub, and the **Event Dispatcher** for complex scenarios like projections and mapping raw events to domain events.
+The Shared Kernel provides two main mechanisms for event distribution: the **Event Broker** for in-memory pub-sub with domain event handlers, and the **Event Dispatcher** for projection-based scenarios.
 
-## 1. Using the Event Broker (In-Memory)
+## 1. Using the Event Broker
 
-The `EventBroker` is used to notify internal subscribers when a domain event occurs within the same process.
+The `EventBroker` is used to notify `DomainEventHandler` subscribers when an infrastructure event is received. It converts raw events into domain events using a `MappingPipeline` and automatically propagates the event's correlation ID through the request context, ensuring `get_request_id()` returns the correct value inside handlers.
 
 ### Define an Event Handler
 
@@ -22,26 +22,33 @@ class WelcomeEmailHandler(DomainEventHandler[UserRegistered]):
 ### Subscribe and Publish
 
 ```python
+from sharedkernel.infrastructure.data import Event
+from sharedkernel.infrastructure.mappers import MappingPipeline
 from sharedkernel.infrastructure.services import EventBroker
 import logging
 
 logger = logging.getLogger(__name__)
-broker = EventBroker(logger)
+
+# The broker needs a mapper to convert raw events to domain events
+mapper = MappingPipeline()
+# ... register mapping behaviors ...
+
+broker = EventBroker(logger, mapper)
 
 # Subscribe the handler
 handler = WelcomeEmailHandler()
 broker.subscribe(handler)
 
-# Publish an event
-event = UserRegistered(email="john@example.com")
-broker.publish(event, position=1)
+# Publish a raw infrastructure event
+raw_event = Event(event_type="UserRegistered", data='{"email": "john@example.com"}', ...)
+broker.publish(raw_event)
 ```
 
 ---
 
-## 2. Using the Event Dispatcher (Projections)
+## 2. Using the Event Dispatcher
 
-The `EventDispatcher` is more specialized. It works with a `MappingPipeline` to convert raw infrastructure events into domain events and passes them to `Projectors`.
+The `EventDispatcher` is used to route infrastructure events to `Projector` subscribers that build and maintain read models. It converts raw events into domain events using a `MappingPipeline` and passes the aggregate's `stream_id` to each projector so it can track positions per entity.
 
 ### Define a Projector
 
@@ -86,3 +93,29 @@ dispatcher.subscribe(projector)
 raw_event = Event(event_type="UserRegistered", data='{"email": "..."}', ...)
 dispatcher.dispatch(raw_event)
 ```
+
+---
+
+## 3. Event Broker vs Event Dispatcher
+
+Both services accept raw `Event` objects and use a `MappingPipeline` to convert them into domain events, but they serve different purposes and target different subscriber types.
+
+| | Event Broker | Event Dispatcher |
+|---|---|---|
+| **Purpose** | Execute side effects and business reactions (sagas) | Build and maintain read models (projections) |
+| **Subscribers** | `DomainEventHandler[TEvent]` | `Projector[TProjection]` |
+| **Correlation ID** | Propagates `event.correlation_id` via `set_request_id()` so downstream handlers and repositories can correlate events back to the originating request | Does not manage request context |
+| **Position tracking** | Passes `event.position` to handlers | Passes `event.position` and `event.stream_id` to projectors, enabling per-entity position tracking and idempotent replay |
+| **Mapper not found** | Logs a warning and skips | Raises `MapperNotFound` |
+
+### When to use the Event Broker
+
+Use the `EventBroker` when consuming events triggers **write-side operations** — commands on other aggregates, integration messages, or saga orchestration. The broker ensures the correlation chain is preserved so that events produced by secondary aggregates can be traced back to the original request.
+
+Typical consumers: Kafka event consumers that feed saga handlers.
+
+### When to use the Event Dispatcher
+
+Use the `EventDispatcher` when consuming events updates **read-side projections** — denormalized views optimized for queries. The dispatcher passes the `stream_id` to projectors so they can track which events have been applied per entity, enabling idempotent replay and ordered processing.
+
+Typical consumers: Event store catch-up subscriptions that feed projectors.

--- a/sharedkernel/application/services.py
+++ b/sharedkernel/application/services.py
@@ -80,6 +80,27 @@ def get_request_id() -> UUID:
     return request_id_var.get(uuid.uuid4())
 
 
+def set_request_id(request_id: UUID) -> contextvars.Token[UUID]:
+    """Sets the current request ID in the context variable.
+
+    Args:
+        request_id: The UUID to set as the current request ID.
+
+    Returns:
+        A Token that can be used to reset the context variable to its previous value.
+    """
+    return request_id_var.set(request_id)
+
+
+def reset_request_id(token: contextvars.Token[UUID]) -> None:
+    """Resets the request ID context variable to its previous value.
+
+    Args:
+        token: The Token returned by a previous call to set_request_id().
+    """
+    request_id_var.reset(token)
+
+
 def error_from_exception(exception: Exception) -> Error:
     """Maps a standard exception to an Error by extracting context from the traceback.
 

--- a/sharedkernel/infrastructure/services.py
+++ b/sharedkernel/infrastructure/services.py
@@ -6,6 +6,7 @@ from types import get_original_bases
 from typing import Any
 from uuid import UUID
 
+from sharedkernel.application.services import reset_request_id, set_request_id
 from sharedkernel.domain.events import DomainEvent, DomainEventHandler
 from sharedkernel.infrastructure.data import Event
 from sharedkernel.infrastructure.exceptions import MapperNotFound, UnprocessableListener, UnsupportedEventHandler
@@ -51,14 +52,17 @@ class EventBroker:
     """Mediates the communication of event messages between producers and consumers.
 
     The Event Broker acts as an in-memory pub-sub mechanism, notifying registered consumers
-    (DomainEventHandlers) when a domain event is published.
+    (DomainEventHandlers) when a domain event is published. Uses a MappingPipeline to convert
+    raw infrastructure events into domain events before dispatching.
 
     Args:
         logger: The logger instance.
+        mapper: The mapping pipeline to convert raw events to domain events.
     """
 
-    def __init__(self, logger: Logger) -> None:
+    def __init__(self, logger: Logger, mapper: MappingPipeline) -> None:
         self._logger = logger
+        self._mapper = mapper
         self._consumers: dict[str, list[DomainEventHandler[DomainEvent]]] = {}
 
     def subscribe(self, event_handler: DomainEventHandler[DomainEvent]) -> bool:
@@ -87,30 +91,41 @@ class EventBroker:
         self._logger.debug(f"{handler_type} was successfully subscribed")
         return True
 
-    def publish(self, event: DomainEvent, position: int) -> None:
-        """Publish a Domain Event to its respective Event Group.
+    def publish(self, event: Event) -> None:
+        """Publish an Event to its respective Consumer Group.
 
-        Look for the Handlers subscribed in the Domain Event Group and notify
-        them to process the Event.
+        Converts the raw infrastructure event into a domain event using the mapping pipeline
+        and notifies all subscribed handlers. Sets the request ID context variable from the
+        event's correlation ID for the duration of handler execution.
 
         Args:
-           event: Domain Event to publish.
-           position: Event position at the Stream
+           event: Infrastructure Event to publish.
 
         Returns:
            None
         """
-        event_type = type(event).__name__
+        event_type = event.event_type
 
         if event_type not in self._consumers:
             self._logger.debug(f"No handler subscribed for {event_type} event")
             return
 
+        event_data = json.loads(event.data)
+
+        domain_event = self._mapper.map(event_data, event_type)
+        if domain_event is None:
+            self._logger.warning(f"No mapper found for {event_type} event")
+            return
+
         consumer_group = self._consumers[event_type]
 
         self._logger.info(f"{event_type} event was published")
-        for consumer in consumer_group:
-            consumer.process(event, position)
+        token = set_request_id(event.correlation_id)
+        try:
+            for consumer in consumer_group:
+                consumer.process(domain_event, event.position)
+        finally:
+            reset_request_id(token)
 
 
 class EventDispatcher:

--- a/tests/infrastructure/event_broker_test.py
+++ b/tests/infrastructure/event_broker_test.py
@@ -1,11 +1,15 @@
 from dataclasses import dataclass
+from datetime import datetime
 from uuid import UUID
 
 import pytest
 
 from sharedkernel.application.commands import Command, CommandHandler
+from sharedkernel.application.services import get_request_id
 from sharedkernel.domain.events import DomainEvent, DomainEventHandler
+from sharedkernel.infrastructure.data import Event
 from sharedkernel.infrastructure.exceptions import UnsupportedEventHandler
+from sharedkernel.infrastructure.mappers import MappingPipeline
 from sharedkernel.infrastructure.services import EventBroker
 
 
@@ -40,16 +44,38 @@ class EmailUserEventHandler(DomainEventHandler[UserRegistered]):
         print(f"{event.event_id} event processed by {type(self).__name__}")
 
 
+class ContextAwareEventHandler(DomainEventHandler[UserRegistered]):
+
+    def process(self, event: UserRegistered, position: int):
+        print(f"{event.event_id} event processed with request_id={get_request_id()}")
+
+
 class RegisterUserCommandHandler(CommandHandler[RegisterUser]):
 
     def execute(self, command: RegisterUser):
         pass
 
 
+class FakeDomainEventMapper(MappingPipeline):
+
+    def map(self, data: dict, data_type: str):
+        return UserRegistered(
+            event_id=data.get("event_id", "UserRegistered"),
+            message=data.get("message", "User(name='John Doe')")
+        )
+
+
+class NoDomainEventMapper(MappingPipeline):
+
+    def map(self, _: dict, __: str):
+        return None
+
+
 def test_event_handler_is_subscribed_to_event_broker(fake_logger):
     # Arrange
     event_handler = RegistrationEventHandler()
-    event_broker = EventBroker(fake_logger)
+    fake_mapper = FakeDomainEventMapper()
+    event_broker = EventBroker(fake_logger, fake_mapper)
 
     # Act
     result = event_broker.subscribe(event_handler)
@@ -63,7 +89,8 @@ def test_two_event_handlers_are_subscribed_to_event_broker(fake_logger):
     registration_handler = RegistrationEventHandler()
     email_handler = EmailUserEventHandler()
 
-    event_broker = EventBroker(fake_logger)
+    fake_mapper = FakeDomainEventMapper()
+    event_broker = EventBroker(fake_logger, fake_mapper)
 
     # Act
     result1 = event_broker.subscribe(registration_handler)
@@ -79,7 +106,8 @@ def test_subscribe_not_event_handler_to_event_broker_raise_error(fake_logger):
     expected = "`RegisterUserCommandHandler` cannot be registered to EventBroker"
 
     command_handler = RegisterUserCommandHandler()
-    event_broker = EventBroker(fake_logger)
+    fake_mapper = FakeDomainEventMapper()
+    event_broker = EventBroker(fake_logger, fake_mapper)
 
     # Act
     with pytest.raises(UnsupportedEventHandler) as error:
@@ -93,13 +121,24 @@ def test_subscribe_not_event_handler_to_event_broker_raise_error(fake_logger):
 def test_domain_event_is_processed_by_subscribed_handler(fake_logger, capture_stdout):
     # Arrange
     event_handler = RegistrationEventHandler()
-    event_broker = EventBroker(fake_logger)
+    fake_mapper = FakeDomainEventMapper()
+    event_broker = EventBroker(fake_logger, fake_mapper)
     subscription_result = event_broker.subscribe(event_handler)
     console = "UserRegistered event processed by RegistrationEventHandler\n"
 
     # Act
-    event = UserRegistered(event_id="UserRegistered", message="User(name='John Doe')")
-    event_broker.publish(event, 1)
+    event = Event(
+        event_id=UUID("018f55de-8321-7efd-a4e3-fcc2c5ec5eea"),
+        event_type="UserRegistered",
+        position=1,
+        data='{"event_id":"UserRegistered", "message":"User(name=\'John Doe\')"}',
+        stream_id=UUID("018f9284-769b-726d-b3bf-3885bf2ddd3c"),
+        stream_type="User",
+        version=1,
+        created=datetime.fromisoformat('2024-04-28T12:30:12-04:00'),
+        correlation_id=UUID('018fa862-800b-7b6a-8690-ba0e06908c26'),
+    )
+    event_broker.publish(event)
 
     # Assert
     assert subscription_result is True
@@ -109,13 +148,106 @@ def test_domain_event_is_processed_by_subscribed_handler(fake_logger, capture_st
 def test_domain_event_is_not_processed_when_no_subscribed_handler(fake_logger, capture_stdout):
     # Arrange
     event_handler = RegistrationEventHandler()
-    event_broker = EventBroker(fake_logger)
+    fake_mapper = FakeDomainEventMapper()
+    event_broker = EventBroker(fake_logger, fake_mapper)
     subscription_result = event_broker.subscribe(event_handler)
 
     # Act
-    event = UserLoggedIn(event_id="UserLoggedIn", message="User(name='John Doe')")
-    event_broker.publish(event, 1)
+    event = Event(
+        event_id=UUID("018f55de-8321-7efd-a4e3-fcc2c5ec5eea"),
+        event_type="UserLoggedIn",
+        position=1,
+        data='{"event_id":"UserLoggedIn", "message":"User(name=\'John Doe\')"}',
+        stream_id=UUID("018f9284-769b-726d-b3bf-3885bf2ddd3c"),
+        stream_type="User",
+        version=1,
+        created=datetime.fromisoformat('2024-04-28T12:30:12-04:00'),
+        correlation_id=UUID('018fa862-800b-7b6a-8690-ba0e06908c26'),
+    )
+    event_broker.publish(event)
 
     # Assert
     assert subscription_result is True
     assert not capture_stdout["console"]
+
+
+def test_domain_event_is_not_processed_when_no_mapper_found(fake_logger, capture_stdout):
+    # Arrange
+    event_handler = RegistrationEventHandler()
+    no_mapper = NoDomainEventMapper()
+    event_broker = EventBroker(fake_logger, no_mapper)
+    subscription_result = event_broker.subscribe(event_handler)
+
+    # Act
+    event = Event(
+        event_id=UUID("018f55de-8321-7efd-a4e3-fcc2c5ec5eea"),
+        event_type="UserRegistered",
+        position=1,
+        data='{"event_id":"UserRegistered", "message":"User(name=\'John Doe\')"}',
+        stream_id=UUID("018f9284-769b-726d-b3bf-3885bf2ddd3c"),
+        stream_type="User",
+        version=1,
+        created=datetime.fromisoformat('2024-04-28T12:30:12-04:00'),
+        correlation_id=UUID('018fa862-800b-7b6a-8690-ba0e06908c26'),
+    )
+    event_broker.publish(event)
+
+    # Assert
+    assert subscription_result is True
+    assert not capture_stdout["console"]
+
+
+def test_event_handler_sees_correct_request_id_when_event_is_published(fake_logger, capture_stdout):
+    # Arrange
+    handler = ContextAwareEventHandler()
+    fake_mapper = FakeDomainEventMapper()
+    event_broker = EventBroker(fake_logger, fake_mapper)
+    event_broker.subscribe(handler)
+    correlation_id = UUID('018fa862-800b-7b6a-8690-ba0e06908c26')
+    console = f"UserRegistered event processed with request_id={correlation_id}\n"
+
+    event = Event(
+        event_id=UUID("018f55de-8321-7efd-a4e3-fcc2c5ec5eea"),
+        event_type="UserRegistered",
+        position=1,
+        data='{"event_id":"UserRegistered", "message":"User(name=\'John Doe\')"}',
+        stream_id=UUID("018f9284-769b-726d-b3bf-3885bf2ddd3c"),
+        stream_type="User",
+        version=1,
+        created=datetime.fromisoformat('2024-04-28T12:30:12-04:00'),
+        correlation_id=correlation_id,
+    )
+
+    # Act
+    event_broker.publish(event)
+
+    # Assert
+    assert capture_stdout["console"] == console
+
+
+def test_request_id_is_reset_after_event_processing(fake_logger):
+    # Arrange
+    handler = ContextAwareEventHandler()
+    fake_mapper = FakeDomainEventMapper()
+    event_broker = EventBroker(fake_logger, fake_mapper)
+    event_broker.subscribe(handler)
+    correlation_id = UUID('018fa862-800b-7b6a-8690-ba0e06908c26')
+
+    event = Event(
+        event_id=UUID("018f55de-8321-7efd-a4e3-fcc2c5ec5eea"),
+        event_type="UserRegistered",
+        position=1,
+        data='{"event_id":"UserRegistered", "message":"User(name=\'John Doe\')"}',
+        stream_id=UUID("018f9284-769b-726d-b3bf-3885bf2ddd3c"),
+        stream_type="User",
+        version=1,
+        created=datetime.fromisoformat('2024-04-28T12:30:12-04:00'),
+        correlation_id=correlation_id,
+    )
+
+    # Act
+    event_broker.publish(event)
+    result = get_request_id()
+
+    # Assert
+    assert result != correlation_id


### PR DESCRIPTION
## Summary

- Add `set_request_id()` and `reset_request_id()` public functions to encapsulate the `request_id_var` ContextVar lifecycle
- Refactor `EventBroker` to accept raw `Event` objects and use `MappingPipeline` for deserialization, aligning with `EventDispatcher` pattern
- `EventBroker.publish()` now manages the request ID ContextVar internally using `event.correlation_id`, ensuring handlers see the correct correlation ID via `get_request_id()`
- Add integration tests verifying the full correlation flow through `EventBroker`
- Update messaging documentation with EventBroker vs EventDispatcher comparison

Closes #116

## Test plan

- [x] All 8 EventBroker tests pass (including 2 new correlation ID integration tests)
- [x] All 161 tests pass with no regressions
- [x] mypy: no issues found
- [x] ruff: all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)