### PR TITLE
feat: Add unit-of-work persistence methods to EventStore and Repository

### DIFF
--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -44,7 +44,7 @@ Orchestrates the flow of data but contains no business logic.
 
 ### 3. Infrastructure Layer (`sharedkernel.infrastructure`)
 Provides technical implementations for domain/application requirements.
-- **Persistence**: `EventStore` interface, `Projections` for building read models.
+- **Persistence**: `EventStore` interface with unit-of-work methods (`stage` to persist without committing, `append` to persist and commit), `Projections` for building read models.
 - **Messaging**: `EventBroker` for in-memory event publishing, `EventDispatcher` for projection-based event routing.
 - **Mapping**: Converting raw data to domain objects via `MappingPipeline`.
 
@@ -61,4 +61,4 @@ The library strictly separates operations that change state (**Commands**) from 
 While optional, the library provides first-class support for **Event Sourcing** via the `Aggregate` and `EventStore` abstractions. Instead of storing the current state, you store the sequence of events that led to that state.
 
 ### Dependency Inversion
-Interfaces (like `Repository`) are defined in the Domain or Application layers, while their concrete implementations reside in the Infrastructure layer. This ensures that business logic is never dependent on database or third-party library choices.
+Interfaces (like `Repository`) are defined in the Domain or Application layers, while their concrete implementations reside in the Infrastructure layer. This ensures that business logic is never dependent on database or third-party library choices. Both `Repository` and `EventStore` expose unit-of-work persistence methods (`add`/`stage` to persist without committing, `save`/`append` to persist and commit) so that command handlers can coordinate multi-aggregate transactions when needed.

--- a/docs/how-to/persistence.md
+++ b/docs/how-to/persistence.md
@@ -4,7 +4,12 @@ The Shared Kernel provides abstract interfaces for data access, allowing your do
 
 ## 1. Using Repositories
 
-**Repositories** are responsible for persisting and retrieving aggregate roots.
+**Repositories** are responsible for persisting and retrieving aggregate roots. The `Repository` interface supports two unit-of-work persistence methods:
+
+- **`save(entity)`** — Persists the entity and **commits** the transaction immediately.
+- **`add(entity)`** — Stores the entity but **leaves the transaction open**, allowing the caller to coordinate multiple operations within a single unit of work before committing.
+
+Use `save` for simple, self-contained operations. Use `add` when you need to persist multiple aggregates or coordinate with an event store within the same transaction.
 
 ### Define the Repository Interface
 
@@ -26,7 +31,11 @@ In your **Infrastructure** layer:
 ```python
 class SqlAlchemyUserRepository(UserRepository):
     def save(self, user: User):
-        # Concrete implementation using SQLAlchemy...
+        # Persists the entity and commits the transaction
+        pass
+
+    def add(self, user: User):
+        # Stores the entity without committing (unit-of-work)
         pass
 
     def find_by_id(self, user_id: UserID) -> User:
@@ -42,15 +51,22 @@ If you are using **Event Sourcing**, you store individual events instead of the 
 
 ### The Event Store Interface
 
-The `EventStore` interface defines an append-only log of events.
+The `EventStore` interface defines an append-only log of events with two unit-of-work persistence methods:
+
+- **`stage(stream_id, events, ...)`** — Stages events to a stream **without committing** the transaction. If a concurrency conflict is detected, the transaction is rolled back and `-1` is returned. Use this when you need to coordinate event persistence with other operations within a single unit of work.
+- **`append(stream_id, events, ...)`** — Appends events to a stream and **commits** the transaction if there is no conflict. Use this for self-contained operations where no further coordination is needed.
 
 ```python
 from sharedkernel.infrastructure.database import EventStore
 from sharedkernel.infrastructure.data import Event
 
 class MyEventStore(EventStore[Event, Stream]):
+    def stage(self, stream_id, events, ...):
+        # Stage events without committing (unit-of-work)...
+        pass
+
     def append(self, stream_id, events, ...):
-        # Append events to your database...
+        # Append events and commit the transaction...
         pass
 
     def get_all(self, stream_id, from_version):

--- a/docs/tutorials/first-aggregate.md
+++ b/docs/tutorials/first-aggregate.md
@@ -59,7 +59,7 @@ class Order(Aggregate[OrderID]):
 When you call `_raise_event(event)`:
 1. The aggregate's `_apply(event)` method is called (ideal for event sourcing).
 2. The event is added to the `changes` collection.
-3. This collection can later be persisted to an `EventStore`.
+3. This collection can later be persisted to an `EventStore` using either `stage` (persist without committing, for unit-of-work coordination) or `append` (persist and commit in one step).
 
 ## 5. Cleaning up
 

--- a/sharedkernel/domain/repositories.py
+++ b/sharedkernel/domain/repositories.py
@@ -28,6 +28,14 @@ class Repository[TEntity: Entity[Any]](ABC):
     #         entity: The entity to save.
     #     """
     #
+    # @abstractmethod
+    # def add(self, entity: TEntity) -> None:
+    #     """Store an entity and leaves the transaction open.
+    #
+    #     Args:
+    #         entity: The entity to save.
+    #     """
+    #
     # def get(self, entity_id: UUID) -> TEntity:
     #     """Gets an entity by its unique identifier.
     #
@@ -37,7 +45,7 @@ class Repository[TEntity: Entity[Any]](ABC):
     #     Returns:
     #         The found entity.
     #
-    #       Raises:
+    #     Raises:
     #         EntityNotFound: If the identifier is not associated to any Entity in the repository.
     #     """
     #
@@ -86,7 +94,7 @@ class ReadRepository(ABC):
     #     Returns:
     #         The found read model details.
     #
-    #       Raises:
+    #     Raises:
     #         EntityNotFound: If the identifier is not associated to any ReadModel in the repository.
     #     """
     #
@@ -99,7 +107,7 @@ class ReadRepository(ABC):
     #     Returns:
     #         The found read model details.
     #
-    #       Raises:
+    #     Raises:
     #         EntityNotFound: If the slug is not associated to any ReadModel in the repository.
     #     """
     #

--- a/sharedkernel/infrastructure/database.py
+++ b/sharedkernel/infrastructure/database.py
@@ -14,6 +14,31 @@ class EventStore[E, S](ABC):
     """
 
     @abstractmethod
+    def stage(
+            self,
+            stream_id: UUID,
+            events: Sequence[DomainEvent],
+            stream_type: str,
+            stream_slug: str,
+            stream_version: int,
+            correlation_id: UUID,
+    ) -> int:
+        """Stages a sequence of events to a stream without committing the transaction.
+        Stage rollback the transaction if there is conflict.
+
+        Args:
+            stream_id: The unique identifier of the stream.
+            events: A sequence of domain events to append.
+            stream_type: The type of the stream (typically the aggregate class name).
+            stream_slug: A human-readable identifier for the stream.
+            stream_version: The version of the stream before appending.
+            correlation_id: The correlation ID for this operation.
+
+        Returns:
+            The event version in the stream, or -1 on concurrency conflict.
+        """
+
+    @abstractmethod
     def append(
             self,
             stream_id: UUID,
@@ -24,6 +49,7 @@ class EventStore[E, S](ABC):
             correlation_id: UUID,
     ) -> int:
         """Appends a sequence of events to a stream in this event store.
+        Append commits the transaction if there is no conflict.
 
         Args:
             stream_id: The unique identifier of the stream.


### PR DESCRIPTION
## Summary

- Add `stage()` method to `EventStore` that appends events without committing, enabling multi-aggregate coordination within a single unit of work
- Add `add()` method to `Repository` that stores an entity without committing the transaction
- Update persistence guide, architecture overview, and first-aggregate tutorial to document the unit-of-work pattern

## Test plan

- [ ] Verify `uv run mypy sharedkernel/` passes with the new `stage` abstract method
- [ ] Verify `uv run ruff check .` passes
- [ ] Verify `uv run tox -e py312` passes
- [ ] Review docs render correctly with `mkdocs serve`

🤖 Generated with [Claude Code](https://claude.com/claude-code)