### PR TITLE
Add parameterized expression output to QuerySpecification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Shared Kernel is a Python 3.12+ library implementing the Shared Kernel pattern for Domain-Driven Design (DDD) and Clean Architecture. It provides base classes and infrastructure for building microservices with CQRS, Event Sourcing, and strict layered architecture.
+Shared Kernel is a Python 3.12+ library implementing the Shared Kernel pattern for Domain-Driven Design (DDD) and Clean
+Architecture. It provides base classes and infrastructure for building microservices with CQRS, Event Sourcing, and
+strict layered architecture.
 
 **Key dependencies:** Pydantic 2.12.5+, typeinspection (custom git dep for generic type introspection).
 
@@ -35,28 +37,41 @@ uv run mypy sharedkernel/
 
 ## Architecture
 
-The library enforces Clean Architecture with four layers. Dependencies point inward (API → Application → Domain ← Infrastructure):
+The library enforces Clean Architecture with four layers. Dependencies point inward (API → Application → Domain ←
+Infrastructure):
 
-- **Domain** (`sharedkernel/domain/`): Pure business logic — ValueObject, Entity, Aggregate, DomainEvent, Guard clauses, Repository interfaces, domain exceptions and errors
-- **Application** (`sharedkernel/application/`): CQRS orchestration — Command/Query handlers, ServiceBus (request router), Validators, RequestContext with contextvars
-- **Infrastructure** (`sharedkernel/infrastructure/`): Technical implementations — EventBroker (in-memory pub-sub), EventDispatcher, MappingPipeline, EventStore interface, JSON encoders
-- **API** (`sharedkernel/api/`): External contracts — Pydantic-based Request/Response models, ProblemDetail error responses, AckResponse
+- **Domain** (`sharedkernel/domain/`): Pure business logic — ValueObject, Entity, Aggregate, DomainEvent, Guard clauses,
+  Repository interfaces, domain exceptions and errors
+- **Application** (`sharedkernel/application/`): CQRS orchestration — Command/Query handlers, ServiceBus (request
+  router), Validators, RequestContext with contextvars
+- **Infrastructure** (`sharedkernel/infrastructure/`): Technical implementations — EventBroker (in-memory pub-sub),
+  EventDispatcher, MappingPipeline, EventStore interface, JSON encoders
+- **API** (`sharedkernel/api/`): External contracts — Pydantic-based Request/Response models, ProblemDetail error
+  responses, AckResponse
 
 ### Key Patterns
 
-- **Exceptions vs Errors:** Exception classes (raised at runtime) live in `exceptions.py` per layer; error data classes (value objects) live in `errors.py`. Each layer has its own base exception (`DomainException`, `ApplicationException`, `InfrastructureException`, `ApiException`) inheriting from `SystemException`.
-- **Exception-based handlers:** Handlers return values directly (`Acknowledgement` or `ReadModel | ReadModelList`) and raise `DomainException` subclasses for business rule violations. The `ServiceBus` catches exceptions and converts them to `Rejection` responses.
+- **Exceptions vs Errors:** Exception classes (raised at runtime) live in `exceptions.py` per layer; error data
+  classes (value objects) live in `errors.py`. Each layer has its own base exception (`DomainException`,
+  `ApplicationException`, `InfrastructureException`, `ApiException`) inheriting from `SystemException`.
+- **Exception-based handlers:** Handlers return values directly (`Acknowledgement` or `ReadModel | ReadModelList`) and
+  raise `DomainException` subclasses for business rule violations. The `ServiceBus` catches exceptions and converts them
+  to `Rejection` responses.
 - **Frozen dataclasses:** ValueObjects and DomainEvents use `@dataclass(frozen=True)` for immutability.
-- **Generic handlers:** `CommandHandler[TCommand]`, `QueryHandler[TQuery]`, `Validator[TRequest]` — the ServiceBus uses type introspection on generic parameters for routing.
-- **ServiceBus:** Uses separate `_command_handlers` and `_query_handlers` dicts for correct type narrowing. Type aliases `Handler`, `Request`, `Response` are defined in `application/services.py`.
-- **Aggregates:** Track domain events via `_events` deque, expose `.changes`, use `_raise_event()` to apply and record events. Support optimistic concurrency via `version` field.
+- **Generic handlers:** `CommandHandler[TCommand]`, `QueryHandler[TQuery]`, `Validator[TRequest]` — the ServiceBus uses
+  type introspection on generic parameters for routing.
+- **ServiceBus:** Uses separate `_command_handlers` and `_query_handlers` dicts for correct type narrowing. Type aliases
+  `Handler`, `Request`, `Response` are defined in `application/services.py`.
+- **Aggregates:** Track domain events via `_events` deque, expose `.changes`, use `_raise_event()` to apply and record
+  events. Support optimistic concurrency via `version` field.
 - **Guard clauses:** Static methods on `Guard` class for fail-fast validation in constructors/factory methods.
 
 ## Code Conventions
 
 - Strict mypy: `disallow_untyped_defs`, `disallow_any_generics`, full type annotations required
-- Ruff linting with broad rule set (E, W, I, N, D, UP, B, C4, SIM, RET, TRY, RSE, ARG, PTH, PL, S, ANN, RUF)
+- Ruff linting with broad rule set (E, W, I, N, D, UP, B, C4, SIM, RET, TRY, RSE, ARG, PTH, PL, S, ANN, SLF RUF)
 - Google docstring convention (`lint.pydocstyle.convention = "google"` in `ruff.toml`)
 - Max line length: 120
-- Tests mirror source structure under `tests/`; test files have relaxed lint rules (no docstrings, annotations, or assert warnings)
+- Tests mirror source structure under `tests/`; test files have relaxed lint rules (no docstrings, annotations, or
+  assert warnings)
 - All generic classes must have explicit type parameters (use `[Any]` when accepting any variant)

--- a/ruff.toml
+++ b/ruff.toml
@@ -18,45 +18,46 @@ lint.extend-select = [
     "PL",
     "S",
     "ANN",
+    "SLF",
     "RUF",
 ]
 
 lint.ignore = [
-    "D100",   # Missing docstring in public module
-    "D104",   # Missing docstring in public package
-    "D105",   # Missing docstring in magic method
-    "D107",   # Missing docstring in __init__
-    "D200",   # One-line docstring should fit on one line
-    "D202",   # No blank lines allowed after function docstring
-    "D204",   # 1 blank line required after class docstring
-    "D205",   # 1 blank line required between summary line and description
-    "D208",   # Docstring is over-indented
-    "D212",   # Multi-line docstring summary should start at the first line
-    "D214",   # Section is over-indented
-    "D401",   # First line of docstring should be in imperative mood
-    "D413",   # Missing blank line after last section
-    "D415",   # First line should end with a period, question mark, or exclamation point
+    "D100", # Missing docstring in public module
+    "D104", # Missing docstring in public package
+    "D105", # Missing docstring in magic method
+    "D107", # Missing docstring in __init__
+    "D200", # One-line docstring should fit on one line
+    "D202", # No blank lines allowed after function docstring
+    "D204", # 1 blank line required after class docstring
+    "D205", # 1 blank line required between summary line and description
+    "D208", # Docstring is over-indented
+    "D212", # Multi-line docstring summary should start at the first line
+    "D214", # Section is over-indented
+    "D401", # First line of docstring should be in imperative mood
+    "D413", # Missing blank line after last section
+    "D415", # First line should end with a period, question mark, or exclamation point
     "ANN401", # Dynamically typed expressions (typing.Any) are disallowed
     "TRY003", # Avoid specifying long messages outside the exception class
     "TRY400", # Use `logging.exception` instead of `logging.error` (intentional: error logged without traceback)
-    "N818",   # Exception name should be named with an Error suffix (public API uses Exception suffix)
-    "B024",   # Abstract base class without abstract methods (intentional facade pattern)
-    "PLR0912",# Too many branches (acceptable for Guard/Detect validation methods)
-    "PLR0913",# Too many arguments (acceptable for EventStore.append)
+    "N818", # Exception name should be named with an Error suffix (public API uses Exception suffix)
+    "B024", # Abstract base class without abstract methods (intentional facade pattern)
+    "PLR0912", # Too many branches (acceptable for Guard/Detect validation methods)
+    "PLR0913", # Too many arguments (acceptable for EventStore.append)
 ]
 
 lint.pydocstyle.convention = "google"
 
 [lint.per-file-ignores]
 "sharedkernel/domain/services.py" = [
-    "S101",   # Assert used for type narrowing on inspect.currentframe()
+    "S101", # Assert used for type narrowing on inspect.currentframe()
 ]
 "tests/**/*.py" = [
-    "S101",   # Use of assert detected
-    "D",      # Missing docstrings
-    "ANN",    # Missing type annotations
+    "S101", # Use of assert detected
+    "D", # Missing docstrings
+    "ANN", # Missing type annotations
     "ARG002", # Unused method argument (fixtures)
-    "PLR2004",# Magic value used in comparison
-    "N806",   # Variable in function should be lowercase (test fixtures using PascalCase callables)
-    "S105",   # Possible hardcoded password (test data)
+    "PLR2004", # Magic value used in comparison
+    "N806", # Variable in function should be lowercase (test fixtures using PascalCase callables)
+    "S105", # Possible hardcoded password (test data)
 ]

--- a/sharedkernel/domain/specifications.py
+++ b/sharedkernel/domain/specifications.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from datetime import datetime
 from enum import StrEnum
+from itertools import count
+from typing import LiteralString
 from uuid import UUID
 
 
@@ -23,6 +25,14 @@ class Predicate(ABC):
     def to_expression(self) -> str:
         """Returns the predicate as a SQL expression string."""
 
+    @abstractmethod
+    def to_template(self) -> LiteralString:
+        """Returns the predicate as a parameterized SQL template string."""
+
+    def build_template(self, _counter: count[int]) -> tuple[LiteralString, dict[str, DataValue]]:
+        """Builds a parameterized SQL template fragment using the shared parameter counter."""
+        return "", {}
+
 
 class Filter(Predicate):
     """Base class for field-level filter predicates."""
@@ -37,6 +47,10 @@ class Filter(Predicate):
 
     def to_expression(self) -> str:
         """Returns the filter as a SQL expression string."""
+        return ""
+
+    def to_template(self) -> LiteralString:
+        """Returns the filter as a parameterized SQL template string."""
         return ""
 
 
@@ -67,12 +81,18 @@ def format_iterable(values: Sequence[DataValue]) -> str:
     return f"({formatted})"
 
 
+def _escape_like(value: DataValue) -> str:
+    """Escapes LIKE-special characters in a value for safe use in LIKE patterns."""
+    return str(value).replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
 class EqualFilter(Filter):
     """Filter for equality comparison (field = value)."""
 
     def __init__(self, field_name: str, value: DataValue) -> None:
         super().__init__(field_name)
         self._value = format_value(value)
+        self._raw_value = value
 
     @property
     def value(self) -> str:
@@ -83,6 +103,11 @@ class EqualFilter(Filter):
         """Returns the filter as a SQL expression string."""
         return f"{self.field_name} = {self.value}"
 
+    def build_template(self, counter: count[int]) -> tuple[LiteralString, dict[str, DataValue]]:
+        """Builds a parameterized SQL template fragment using the shared parameter counter."""
+        key = f"p{next(counter)}"
+        return f"{self.field_name} = %({key})s", {key: self._raw_value}
+
 
 class NotEqualFilter(Filter):
     """Filter for inequality comparison (field != value)."""
@@ -90,6 +115,7 @@ class NotEqualFilter(Filter):
     def __init__(self, field_name: str, value: DataValue) -> None:
         super().__init__(field_name)
         self._value = format_value(value)
+        self._raw_value = value
 
     @property
     def value(self) -> str:
@@ -100,6 +126,11 @@ class NotEqualFilter(Filter):
         """Returns the filter as a SQL expression string."""
         return f"{self.field_name} != {self.value}"
 
+    def build_template(self, counter: count[int]) -> tuple[LiteralString, dict[str, DataValue]]:
+        """Builds a parameterized SQL template fragment using the shared parameter counter."""
+        key = f"p{next(counter)}"
+        return f"{self.field_name} != %({key})s", {key: self._raw_value}
+
 
 class LessThanFilter(Filter):
     """Filter for less-than comparison (field < value)."""
@@ -107,6 +138,7 @@ class LessThanFilter(Filter):
     def __init__(self, field_name: str, value: DataValue) -> None:
         super().__init__(field_name)
         self._value = format_value(value)
+        self._raw_value = value
 
     @property
     def value(self) -> str:
@@ -117,6 +149,11 @@ class LessThanFilter(Filter):
         """Returns the filter as a SQL expression string."""
         return f"{self.field_name} < {self.value}"
 
+    def build_template(self, counter: count[int]) -> tuple[LiteralString, dict[str, DataValue]]:
+        """Builds a parameterized SQL template fragment using the shared parameter counter."""
+        key = f"p{next(counter)}"
+        return f"{self.field_name} < %({key})s", {key: self._raw_value}
+
 
 class LessThanOrEqualFilter(Filter):
     """Filter for less-than-or-equal comparison (field <= value)."""
@@ -124,6 +161,7 @@ class LessThanOrEqualFilter(Filter):
     def __init__(self, field_name: str, value: DataValue) -> None:
         super().__init__(field_name)
         self._value = format_value(value)
+        self._raw_value = value
 
     @property
     def value(self) -> str:
@@ -134,6 +172,11 @@ class LessThanOrEqualFilter(Filter):
         """Returns the filter as a SQL expression string."""
         return f"{self.field_name} <= {self.value}"
 
+    def build_template(self, counter: count[int]) -> tuple[LiteralString, dict[str, DataValue]]:
+        """Builds a parameterized SQL template fragment using the shared parameter counter."""
+        key = f"p{next(counter)}"
+        return f"{self.field_name} <= %({key})s", {key: self._raw_value}
+
 
 class GreaterThanFilter(Filter):
     """Filter for greater-than comparison (field > value)."""
@@ -141,6 +184,7 @@ class GreaterThanFilter(Filter):
     def __init__(self, field_name: str, value: DataValue) -> None:
         super().__init__(field_name)
         self._value = format_value(value)
+        self._raw_value = value
 
     @property
     def value(self) -> str:
@@ -151,6 +195,11 @@ class GreaterThanFilter(Filter):
         """Returns the filter as a SQL expression string."""
         return f"{self.field_name} > {self.value}"
 
+    def build_template(self, counter: count[int]) -> tuple[LiteralString, dict[str, DataValue]]:
+        """Builds a parameterized SQL template fragment using the shared parameter counter."""
+        key = f"p{next(counter)}"
+        return f"{self.field_name} > %({key})s", {key: self._raw_value}
+
 
 class GreaterThanOrEqualFilter(Filter):
     """Filter for greater-than-or-equal comparison (field >= value)."""
@@ -158,6 +207,7 @@ class GreaterThanOrEqualFilter(Filter):
     def __init__(self, field_name: str, value: DataValue) -> None:
         super().__init__(field_name)
         self._value = format_value(value)
+        self._raw_value = value
 
     @property
     def value(self) -> str:
@@ -168,6 +218,11 @@ class GreaterThanOrEqualFilter(Filter):
         """Returns the filter as a SQL expression string."""
         return f"{self.field_name} >= {self.value}"
 
+    def build_template(self, counter: count[int]) -> tuple[LiteralString, dict[str, DataValue]]:
+        """Builds a parameterized SQL template fragment using the shared parameter counter."""
+        key = f"p{next(counter)}"
+        return f"{self.field_name} >= %({key})s", {key: self._raw_value}
+
 
 class InFilter(Filter):
     """Filter for set membership (field IN (values))."""
@@ -175,6 +230,7 @@ class InFilter(Filter):
     def __init__(self, field_name: str, values: Sequence[DataValue]) -> None:
         super().__init__(field_name)
         self._values = format_iterable(values)
+        self._raw_values = tuple(values)
 
     @property
     def values(self) -> str:
@@ -185,6 +241,17 @@ class InFilter(Filter):
         """Returns the filter as a SQL expression string."""
         return f"{self.field_name} IN {self.values}"
 
+    def build_template(self, counter: count[int]) -> tuple[LiteralString, dict[str, DataValue]]:
+        """Builds a parameterized SQL template fragment using the shared parameter counter."""
+        params: dict[str, DataValue] = {}
+        placeholders: list[str] = []
+        for val in self._raw_values:
+            key = f"p{next(counter)}"
+            params[key] = val
+            placeholders.append(f"%({key})s")
+        joined = ", ".join(placeholders)
+        return f"{self.field_name} IN ({joined})", params
+
 
 class NotInFilter(Filter):
     """Filter for set exclusion (field NOT IN (values))."""
@@ -192,6 +259,7 @@ class NotInFilter(Filter):
     def __init__(self, field_name: str, values: Sequence[DataValue]) -> None:
         super().__init__(field_name)
         self._values = format_iterable(values)
+        self._raw_values = tuple(values)
 
     @property
     def values(self) -> str:
@@ -202,6 +270,17 @@ class NotInFilter(Filter):
         """Returns the filter as a SQL expression string."""
         return f"{self.field_name} NOT IN {self.values}"
 
+    def build_template(self, counter: count[int]) -> tuple[LiteralString, dict[str, DataValue]]:
+        """Builds a parameterized SQL template fragment using the shared parameter counter."""
+        params: dict[str, DataValue] = {}
+        placeholders: list[str] = []
+        for val in self._raw_values:
+            key = f"p{next(counter)}"
+            params[key] = val
+            placeholders.append(f"%({key})s")
+        joined = ", ".join(placeholders)
+        return f"{self.field_name} NOT IN ({joined})", params
+
 
 class BetweenFilter(Filter):
     """Filter for range inclusion (field BETWEEN left AND right)."""
@@ -210,6 +289,8 @@ class BetweenFilter(Filter):
         super().__init__(field_name)
         self._left_value = format_value(left)
         self._right_value = format_value(right)
+        self._raw_left = left
+        self._raw_right = right
 
     @property
     def left(self) -> str:
@@ -224,6 +305,13 @@ class BetweenFilter(Filter):
     def to_expression(self) -> str:
         """Returns the filter as a SQL expression string."""
         return f"{self.field_name} BETWEEN {self.left} AND {self.right}"
+
+    def build_template(self, counter: count[int]) -> tuple[LiteralString, dict[str, DataValue]]:
+        """Builds a parameterized SQL template fragment using the shared parameter counter."""
+        k1 = f"p{next(counter)}"
+        k2 = f"p{next(counter)}"
+        return f"{self.field_name} BETWEEN %({k1})s AND %({k2})s", {k1: self._raw_left,
+                                                                    k2: self._raw_right}
 
 
 class ContainsFilter(Filter):
@@ -243,6 +331,12 @@ class ContainsFilter(Filter):
         """Returns the filter as a SQL expression string."""
         return f"{self.field_name} LIKE '%{self._raw_value}%'"
 
+    def build_template(self, counter: count[int]) -> tuple[LiteralString, dict[str, DataValue]]:
+        """Builds a parameterized SQL template fragment using the shared parameter counter."""
+        key = f"p{next(counter)}"
+        escaped = _escape_like(self._raw_value)
+        return f"{self.field_name} LIKE %({key})s", {key: f"%{escaped}%"}
+
 
 class NotContainsFilter(Filter):
     """Filter for substring exclusion (field NOT LIKE '%value%')."""
@@ -260,6 +354,12 @@ class NotContainsFilter(Filter):
     def to_expression(self) -> str:
         """Returns the filter as a SQL expression string."""
         return f"{self.field_name} NOT LIKE '%{self._raw_value}%'"
+
+    def build_template(self, counter: count[int]) -> tuple[LiteralString, dict[str, DataValue]]:
+        """Builds a parameterized SQL template fragment using the shared parameter counter."""
+        key = f"p{next(counter)}"
+        escaped = _escape_like(self._raw_value)
+        return f"{self.field_name} NOT LIKE %({key})s", {key: f"%{escaped}%"}
 
 
 class StartsWithFilter(Filter):
@@ -279,6 +379,12 @@ class StartsWithFilter(Filter):
         """Returns the filter as a SQL expression string."""
         return f"{self.field_name} LIKE '{self._raw_value}%'"
 
+    def build_template(self, counter: count[int]) -> tuple[LiteralString, dict[str, DataValue]]:
+        """Builds a parameterized SQL template fragment using the shared parameter counter."""
+        key = f"p{next(counter)}"
+        escaped = _escape_like(self._raw_value)
+        return f"{self.field_name} LIKE %({key})s", {key: f"{escaped}%"}
+
 
 class EndsWithFilter(Filter):
     """Filter for suffix match (field LIKE '%value')."""
@@ -297,6 +403,12 @@ class EndsWithFilter(Filter):
         """Returns the filter as a SQL expression string."""
         return f"{self.field_name} LIKE '%{self._raw_value}'"
 
+    def build_template(self, counter: count[int]) -> tuple[LiteralString, dict[str, DataValue]]:
+        """Builds a parameterized SQL template fragment using the shared parameter counter."""
+        key = f"p{next(counter)}"
+        escaped = _escape_like(self._raw_value)
+        return f"{self.field_name} LIKE %({key})s", {key: f"%{escaped}"}
+
 
 class IsNullFilter(Filter):
     """Filter for null check (field IS NULL)."""
@@ -307,6 +419,10 @@ class IsNullFilter(Filter):
     def to_expression(self) -> str:
         """Returns the filter as a SQL expression string."""
         return f"{self.field_name} IS NULL"
+
+    def build_template(self, _counter: count[int]) -> tuple[LiteralString, dict[str, DataValue]]:
+        """Builds a parameterized SQL template fragment using the shared parameter counter."""
+        return f"{self.field_name} IS NULL", {}
 
 
 class IsNotNullFilter(Filter):
@@ -319,6 +435,10 @@ class IsNotNullFilter(Filter):
         """Returns the filter as a SQL expression string."""
         return f"{self.field_name} IS NOT NULL"
 
+    def build_template(self, _counter: count[int]) -> tuple[LiteralString, dict[str, DataValue]]:
+        """Builds a parameterized SQL template fragment using the shared parameter counter."""
+        return f"{self.field_name} IS NOT NULL", {}
+
 
 class Condition(Predicate):
     """A predicate that wraps a Filter with factory classmethods for creation."""
@@ -329,6 +449,16 @@ class Condition(Predicate):
     def to_expression(self) -> str:
         """Returns the condition as a SQL expression string."""
         return self._filter.to_expression()
+
+    def to_template(self) -> LiteralString:
+        """Returns the condition as a parameterized SQL template string."""
+        counter = count()
+        template, _ = self._filter.build_template(counter)
+        return template
+
+    def build_template(self, counter: count[int]) -> tuple[LiteralString, dict[str, DataValue]]:
+        """Builds a parameterized SQL template fragment using the shared parameter counter."""
+        return self._filter.build_template(counter)
 
     @classmethod
     def equal(cls, field_name: str, value: DataValue) -> Condition:
@@ -444,6 +574,29 @@ class PredicateGroup(Predicate):
 
         return separator.join(expressions)
 
+    def to_template(self) -> LiteralString:
+        """Returns the predicate group as a parameterized SQL template string."""
+        counter = count()
+        template, _ = self.build_template(counter)
+        return template
+
+    def build_template(self, counter: count[int]) -> tuple[LiteralString, dict[str, DataValue]]:
+        """Builds a parameterized SQL template fragment using the shared parameter counter."""
+        if not self.predicates:
+            return "", {}
+
+        templates: list[str] = []
+        all_params: dict[str, DataValue] = {}
+        for predicate in self.predicates:
+            tmpl, params = predicate.build_template(counter)
+            if isinstance(predicate, PredicateGroup):
+                tmpl = f"({tmpl})"
+            templates.append(tmpl)
+            all_params.update(params)
+
+        separator = f" {self.operator.value} "
+        return separator.join(templates), all_params
+
     def __and__(self, other: PredicateGroup) -> PredicateGroup:
         if self.operator != other.operator:
             return PredicateGroup(self.operator, [self, other])
@@ -518,12 +671,23 @@ class Specification(ABC):
     def to_expression(self) -> str:
         """Returns the specification as a SQL expression string."""
 
+    @abstractmethod
+    def to_template(self) -> LiteralString:
+        """Returns the specification as a parameterized SQL template string."""
+
+    @property
+    @abstractmethod
+    def parameters(self) -> Mapping[str, DataValue]:
+        """Returns the named parameters for the parameterized SQL template."""
+
 
 class QuerySpecification(Specification):
     """A complete query specification combining predicates, sorting, and pagination."""
 
     def __init__(
-        self, pagination: Pagination, sorting: Sequence[SortOrder] | None = None, predicate: Predicate | None = None,
+            self, pagination: Pagination,
+            sorting: Sequence[SortOrder] | None = None,
+            predicate: Predicate | None = None,
     ) -> None:
         self._predicate = predicate
         self._sorting = tuple(sorting) if sorting else ()
@@ -544,6 +708,16 @@ class QuerySpecification(Specification):
         """The pagination parameters for the query."""
         return self._pagination
 
+    @property
+    def limit(self) -> int:
+        """The maximum number of results to return."""
+        return self._pagination.limit
+
+    @property
+    def offset(self) -> int:
+        """The number of results to skip."""
+        return self._pagination.offset
+
     def to_expression(self) -> str:
         """Returns the full query specification as a SQL expression string."""
         parts: list[str] = []
@@ -558,3 +732,31 @@ class QuerySpecification(Specification):
         parts.append(self.pagination.to_expression())
 
         return " ".join(parts)
+
+    def to_template(self) -> LiteralString:
+        """Returns the full query specification as a parameterized SQL template string."""
+        template, _ = self._build_template()
+        return template
+
+    @property
+    def parameters(self) -> Mapping[str, DataValue]:
+        """Returns the named parameters for the parameterized SQL template."""
+        _, params = self._build_template()
+        return params
+
+    def _build_template(self) -> tuple[LiteralString, dict[str, DataValue]]:
+        parts: list[str] = []
+        params: dict[str, DataValue] = {}
+        counter = count()
+
+        if self.predicate:
+            tmpl, params = self.predicate.build_template(counter)
+            parts.append(f"WHERE {tmpl}")
+
+        if self.sorting:
+            sorting_expression = ", ".join(sort.to_expression() for sort in self.sorting)
+            parts.append(f"ORDER BY {sorting_expression}")
+
+        parts.append(self.pagination.to_expression())
+
+        return " ".join(parts), params

--- a/tests/domain/specifications_test.py
+++ b/tests/domain/specifications_test.py
@@ -615,3 +615,453 @@ def test_specification_queries_with_country_do_ordered_by_last_name_asc_limit_10
 
     # Assert
     assert result == "WHERE country = 'DO' ORDER BY last_name ASC LIMIT 10 OFFSET 0"
+
+
+def test_specification_template_with_country_equal_do():
+    # Arrange
+    predicate = Condition.equal(field_name='country', value='DO')
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template = specification.to_template()
+    parameters = specification.parameters
+
+    # Assert
+    assert template == "WHERE country = %(p0)s LIMIT 50 OFFSET 0"
+    assert parameters == {'p0': 'DO'}
+
+
+def test_specification_template_with_active_equal_true():
+    # Arrange
+    predicate = Condition.equal(field_name='active', value=True)
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template = specification.to_template()
+    parameters = specification.parameters
+
+    # Assert
+    assert template == "WHERE active = %(p0)s LIMIT 50 OFFSET 0"
+    assert parameters == {'p0': True}
+
+
+def test_specification_template_with_status_not_equal_inactive():
+    # Arrange
+    predicate = Condition.not_equal(field_name='status', value='inactive')
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template = specification.to_template()
+    parameters = specification.parameters
+
+    # Assert
+    assert template == "WHERE status != %(p0)s LIMIT 50 OFFSET 0"
+    assert parameters == {'p0': 'inactive'}
+
+
+def test_specification_template_with_capacity_less_than_5000():
+    # Arrange
+    predicate = Condition.less_than(field_name='capacity', value=5000)
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template = specification.to_template()
+    parameters = specification.parameters
+
+    # Assert
+    assert template == "WHERE capacity < %(p0)s LIMIT 50 OFFSET 0"
+    assert parameters == {'p0': 5000}
+
+
+def test_specification_template_with_weight_less_than_or_equal_95_5():
+    # Arrange
+    predicate = Condition.less_than_or_equal(field_name='weight', value=95.5)
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template = specification.to_template()
+    parameters = specification.parameters
+
+    # Assert
+    assert template == "WHERE weight <= %(p0)s LIMIT 50 OFFSET 0"
+    assert parameters == {'p0': 95.5}
+
+
+def test_specification_template_with_year_greater_than_2020():
+    # Arrange
+    predicate = Condition.greater_than(field_name='year', value=2020)
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template = specification.to_template()
+    parameters = specification.parameters
+
+    # Assert
+    assert template == "WHERE year > %(p0)s LIMIT 50 OFFSET 0"
+    assert parameters == {'p0': 2020}
+
+
+def test_specification_template_with_capacity_greater_than_or_equal_5000():
+    # Arrange
+    predicate = Condition.greater_than_or_equal(field_name='capacity', value=5000)
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template = specification.to_template()
+    parameters = specification.parameters
+
+    # Assert
+    assert template == "WHERE capacity >= %(p0)s LIMIT 50 OFFSET 0"
+    assert parameters == {'p0': 5000}
+
+
+def test_specification_template_with_coach_id_equal_uuid():
+    # Arrange
+    predicate = Condition.equal(field_name='coach_id', value=UUID('01926a3e-5b7c-7000-8000-000100000000'))
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template = specification.to_template()
+    parameters = specification.parameters
+
+    # Assert
+    assert template == "WHERE coach_id = %(p0)s LIMIT 50 OFFSET 0"
+    assert parameters == {'p0': UUID('01926a3e-5b7c-7000-8000-000100000000')}
+
+
+def test_specification_template_with_game_date_equal_datetime():
+    # Arrange
+    predicate = Condition.equal(field_name='game_date', value=datetime(2024, 6, 15, 19, 0, 0, tzinfo=UTC))
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template = specification.to_template()
+    parameters = specification.parameters
+
+    # Assert
+    assert template == "WHERE game_date = %(p0)s LIMIT 50 OFFSET 0"
+    assert parameters == {'p0': datetime(2024, 6, 15, 19, 0, 0, tzinfo=UTC)}
+
+
+def test_specification_template_with_country_in_do_us_pr():
+    # Arrange
+    predicate = Condition.is_in(field_name='country', values=['DO', 'US', 'PR'])
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template = specification.to_template()
+    parameters = specification.parameters
+
+    # Assert
+    assert template == "WHERE country IN (%(p0)s, %(p1)s, %(p2)s) LIMIT 50 OFFSET 0"
+    assert parameters == {'p0': 'DO', 'p1': 'US', 'p2': 'PR'}
+
+
+def test_specification_template_with_status_not_in_inactive_archived():
+    # Arrange
+    predicate = Condition.not_in(field_name='status', values=['inactive', 'archived'])
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template = specification.to_template()
+    parameters = specification.parameters
+
+    # Assert
+    assert template == "WHERE status NOT IN (%(p0)s, %(p1)s) LIMIT 50 OFFSET 0"
+    assert parameters == {'p0': 'inactive', 'p1': 'archived'}
+
+
+def test_specification_template_with_year_between_2024_and_2026():
+    # Arrange
+    predicate = Condition.between(field_name='year', left=2024, right=2026)
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template = specification.to_template()
+    parameters = specification.parameters
+
+    # Assert
+    assert template == "WHERE year BETWEEN %(p0)s AND %(p1)s LIMIT 50 OFFSET 0"
+    assert parameters == {'p0': 2024, 'p1': 2026}
+
+
+def test_specification_template_with_slug_contains_garcia():
+    # Arrange
+    predicate = Condition.contains(field_name='slug', value='garcia')
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template = specification.to_template()
+    parameters = specification.parameters
+
+    # Assert
+    assert template == "WHERE slug LIKE %(p0)s LIMIT 50 OFFSET 0"
+    assert parameters == {'p0': '%garcia%'}
+
+
+def test_specification_template_with_slug_not_contains_test():
+    # Arrange
+    predicate = Condition.not_contains(field_name='slug', value='test')
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template = specification.to_template()
+    parameters = specification.parameters
+
+    # Assert
+    assert template == "WHERE slug NOT LIKE %(p0)s LIMIT 50 OFFSET 0"
+    assert parameters == {'p0': '%test%'}
+
+
+def test_specification_template_with_slug_starts_with_garcia():
+    # Arrange
+    predicate = Condition.starts_with(field_name='slug', value='garcia')
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template = specification.to_template()
+    parameters = specification.parameters
+
+    # Assert
+    assert template == "WHERE slug LIKE %(p0)s LIMIT 50 OFFSET 0"
+    assert parameters == {'p0': 'garcia%'}
+
+
+def test_specification_template_with_slug_ends_with_jr():
+    # Arrange
+    predicate = Condition.ends_with(field_name='slug', value='jr')
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template = specification.to_template()
+    parameters = specification.parameters
+
+    # Assert
+    assert template == "WHERE slug LIKE %(p0)s LIMIT 50 OFFSET 0"
+    assert parameters == {'p0': '%jr'}
+
+
+def test_specification_template_with_label_contains_100_percent():
+    # Arrange
+    predicate = Condition.contains(field_name='label', value='100%')
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template = specification.to_template()
+    parameters = specification.parameters
+
+    # Assert
+    assert template == "WHERE label LIKE %(p0)s LIMIT 50 OFFSET 0"
+    assert parameters == {'p0': '%100\\%%'}
+
+
+def test_specification_template_with_name_contains_under_score():
+    # Arrange
+    predicate = Condition.contains(field_name='name', value='user_name')
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template = specification.to_template()
+    parameters = specification.parameters
+
+    # Assert
+    assert template == "WHERE name LIKE %(p0)s LIMIT 50 OFFSET 0"
+    assert parameters == {'p0': '%user\\_name%'}
+
+
+def test_specification_template_with_label_starts_with_50_percent_off():
+    # Arrange
+    predicate = Condition.starts_with(field_name='label', value='50% off')
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template = specification.to_template()
+    parameters = specification.parameters
+
+    # Assert
+    assert template == "WHERE label LIKE %(p0)s LIMIT 50 OFFSET 0"
+    assert parameters == {'p0': '50\\% off%'}
+
+
+def test_specification_template_with_description_is_null():
+    # Arrange
+    predicate = Condition.is_null(field_name='description')
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template = specification.to_template()
+    parameters = specification.parameters
+
+    # Assert
+    assert template == "WHERE description IS NULL LIMIT 50 OFFSET 0"
+    assert parameters == {}
+
+
+def test_specification_template_with_headshot_url_is_not_null():
+    # Arrange
+    predicate = Condition.is_not_null(field_name='headshot_url')
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template = specification.to_template()
+    parameters = specification.parameters
+
+    # Assert
+    assert template == "WHERE headshot_url IS NOT NULL LIMIT 50 OFFSET 0"
+    assert parameters == {}
+
+
+def test_specification_template_with_country_do_and_sex_male_and_status_active():
+    # Arrange
+    predicate = PredicateGroup(operator=LogicalOperator.AND, predicates=[
+        Condition.equal(field_name='country', value='DO'),
+        Condition.equal(field_name='sex', value='male'),
+        Condition.equal(field_name='status', value='active'),
+    ])
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template = specification.to_template()
+    parameters = specification.parameters
+
+    # Assert
+    assert template == "WHERE country = %(p0)s AND sex = %(p1)s AND status = %(p2)s LIMIT 50 OFFSET 0"
+    assert parameters == {'p0': 'DO', 'p1': 'male', 'p2': 'active'}
+
+
+def test_specification_template_with_last_name_contains_garcia_and_country_do():
+    # Arrange
+    predicate = PredicateGroup(operator=LogicalOperator.AND, predicates=[
+        Condition.contains(field_name='last_name', value='garcia'),
+        Condition.equal(field_name='country', value='DO'),
+    ])
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template = specification.to_template()
+    parameters = specification.parameters
+
+    # Assert
+    assert template == "WHERE last_name LIKE %(p0)s AND country = %(p1)s LIMIT 50 OFFSET 0"
+    assert parameters == {'p0': '%garcia%', 'p1': 'DO'}
+
+
+def test_specification_template_with_position_pg_or_pts_gt_20_and_ast_gt_10():
+    # Arrange
+    expression1 = PredicateGroup(operator=LogicalOperator.OR, predicates=[
+        Condition.equal(field_name='position', value='PG'),
+    ])
+    expression2 = PredicateGroup(operator=LogicalOperator.AND, predicates=[
+        Condition.greater_than(field_name='pts', value=20),
+        Condition.greater_than(field_name='ast', value=10),
+    ])
+    predicate = expression1 | expression2
+    pagination = Pagination()
+    expected = "WHERE (position = %(p0)s) OR (pts > %(p1)s AND ast > %(p2)s) LIMIT 50 OFFSET 0"
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template = specification.to_template()
+    parameters = specification.parameters
+
+    # Assert
+    assert template == expected
+    assert parameters == {'p0': 'PG', 'p1': 20, 'p2': 10}
+
+
+def test_specification_template_with_position_sg_and_pts_gt_20_or_ast_gt_10():
+    # Arrange
+    expression1 = PredicateGroup(operator=LogicalOperator.AND, predicates=[
+        Condition.equal(field_name='position', value='SG'),
+    ])
+    expression2 = PredicateGroup(operator=LogicalOperator.OR, predicates=[
+        Condition.greater_than(field_name='pts', value=20),
+        Condition.greater_than(field_name='ast', value=10),
+    ])
+    predicate = expression1 & expression2
+    pagination = Pagination()
+    expected = "WHERE (position = %(p0)s) AND (pts > %(p1)s OR ast > %(p2)s) LIMIT 50 OFFSET 0"
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template = specification.to_template()
+    parameters = specification.parameters
+
+    # Assert
+    assert template == expected
+    assert parameters == {'p0': 'SG', 'p1': 20, 'p2': 10}
+
+
+def test_specification_template_with_country_do_ordered_by_last_name_asc_limit_10_offset_0():
+    # Arrange
+    predicate = Condition.equal(field_name='country', value='DO')
+    sorting = [SortOrder(field_name='last_name', direction=SortDirection.ASC)]
+    pagination = Pagination(limit=10, offset=0)
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, sorting=sorting, pagination=pagination)
+    template = specification.to_template()
+    parameters = specification.parameters
+
+    # Assert
+    assert template == "WHERE country = %(p0)s ORDER BY last_name ASC LIMIT 10 OFFSET 0"
+    assert parameters == {'p0': 'DO'}
+
+
+def test_specification_template_with_no_predicate_limit_25_offset_10():
+    # Arrange
+    pagination = Pagination(limit=25, offset=10)
+
+    # Act
+    specification = QuerySpecification(pagination=pagination)
+    template = specification.to_template()
+    parameters = specification.parameters
+
+    # Assert
+    assert template == "LIMIT 25 OFFSET 10"
+    assert parameters == {}
+
+
+def test_specification_limit_delegates_to_pagination():
+    # Arrange
+    pagination = Pagination(limit=10, offset=5)
+
+    # Act
+    specification = QuerySpecification(pagination=pagination)
+
+    # Assert
+    assert specification.limit == 10
+
+
+def test_specification_offset_delegates_to_pagination():
+    # Arrange
+    pagination = Pagination(limit=10, offset=5)
+
+    # Act
+    specification = QuerySpecification(pagination=pagination)
+
+    # Assert
+    assert specification.offset == 5


### PR DESCRIPTION
## Summary

- Add `to_template() -> LiteralString` and `parameters -> Mapping[str, DataValue]` to `QuerySpecification` for SQL injection-safe query building with named `%(pN)s` placeholders
- Add `limit` and `offset` convenience properties to `QuerySpecification`
- Add `build_template(counter)` public method to `Predicate` ABC for counter-threaded template building across the predicate tree
- LIKE filters (`contains`, `not_contains`, `starts_with`, `ends_with`) escape wildcard metacharacters (`%` and `_`) in user-supplied values
- Existing `to_expression()` remains unchanged — full backward compatibility

## Test plan

- [x] 29 new parameterized template tests (all filter types, wildcard escaping, composites, properties)
- [x] 43 existing `to_expression()` tests pass unchanged (no regressions)
- [x] Full tox suite passes (233 tests)
- [x] mypy strict mode passes
- [x] ruff passes (including new SLF rule)

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)