### PR TITLE
chore: Bump version to 7.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to Shared Kernel will be documented in this file.
 
+## 7.2.0 (2026-05-21)
+
+### Added
+
+- Parameterized expression output (`to_template()` method and `parameters` property) on `QuerySpecification` for SQL injection-safe query building with named placeholders.
+- LIKE filters automatically escape wildcard metacharacters (`%` and `_`) in user values.
+
+### Changed
+
+- `Filter._field_name` annotated as `LiteralString` to document the trust boundary for parameterized SQL template safety.
+- `QuerySpecification` caches template build result to avoid double predicate tree traversal.
+- `limit` and `offset` promoted to abstract properties on `Specification` base class.
+
 ## 7.1.0 (2026-05-18)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Shared Kernel is built using Python 3.12 and depends on the follow libraries:
 To install Share Kernel using pip, run:
 
 ```shell
-pip install git+https://github.com/juanluiscr27/shared-kernel.git@v7.1.0#egg=sharedkernel
+pip install git+https://github.com/juanluiscr27/shared-kernel.git@v7.2.0#egg=sharedkernel
 ```
 
 ## Usage

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ maintaining clean boundaries.
 ### Installation
 
 ```bash
-pip install git+https://github.com/juanluiscr27/shared-kernel.git@v7.1.0#egg=sharedkernel
+pip install git+https://github.com/juanluiscr27/shared-kernel.git@v7.2.0#egg=sharedkernel
 ```
 
 ### Basic Example: Value Objects

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sharedkernel"
-version = "7.1.0"
+version = "7.2.0"
 description = "Shared Kernel for clean architecture projects"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -428,7 +428,7 @@ wheels = [
 
 [[package]]
 name = "sharedkernel"
-version = "7.1.0"
+version = "7.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

- Bump version from 7.1.0 to 7.2.0 in `pyproject.toml`, `README.md`, `docs/index.md`, and `uv.lock`
- Add changelog entry documenting parameterized expression output on `QuerySpecification` and Specification type safety improvements

## Test plan

- [x] `uv run ruff check .` — all checks passed
- [x] `uv run mypy sharedkernel/` — no issues found
- [x] `uv run tox -e py312` — 233 tests passed
- [x] Grep confirms no stale `7.1.0` references outside historical changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)