### PR TITLE
Realign Specification parameterized API with original design

### DIFF
--- a/docs/how-to/persistence.md
+++ b/docs/how-to/persistence.md
@@ -157,6 +157,34 @@ specification.to_expression()
 # "WHERE country = 'DO' ORDER BY last_name ASC LIMIT 10 OFFSET 0"
 ```
 
+### Parameterized Statements
+
+`to_statement()` returns a `(template, params)` tuple for SQL injection-safe query building with named placeholders:
+
+```python
+sql, params = specification.to_statement()
+# sql    → "WHERE country = %(p0)s ORDER BY last_name ASC LIMIT 10 OFFSET 0"
+# params → {'p0': 'DO'}
+```
+
+Use `to_filter()` when you only need the WHERE clause without sorting or pagination:
+
+```python
+sql, params = specification.to_filter()
+# sql    → "WHERE country = %(p0)s"
+# params → {'p0': 'DO'}
+```
+
+Both methods accept an optional `alias` parameter to qualify field names with a table alias:
+
+```python
+sql, params = specification.to_statement(alias='t')
+# sql    → "WHERE t.country = %(p0)s ORDER BY t.last_name ASC LIMIT 10 OFFSET 0"
+# params → {'p0': 'DO'}
+```
+
+### Using with a Repository
+
 `QuerySpecification` implements the `Specification` interface, which `ReadRepository.find_all` accepts. Your infrastructure layer translates the specification into the appropriate database query:
 
 ```python
@@ -165,9 +193,9 @@ from sharedkernel.domain.specifications import Specification
 
 class SqlAlchemyPlayerRepository(ReadRepository):
     def find_all(self, specification: Specification) -> ReadModelList:
-        query = self._build_query(specification.to_expression())
-        # Translate and execute against your database...
-        pass
+        sql, params = specification.to_statement(alias='p')
+        cursor.execute(f"SELECT ... FROM players p {sql}", params)
+        ...
 ```
 
 ---

--- a/sharedkernel/domain/specifications.py
+++ b/sharedkernel/domain/specifications.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from datetime import datetime
 from enum import StrEnum
 from itertools import count
@@ -25,11 +25,7 @@ class Predicate(ABC):
     def to_expression(self) -> str:
         """Returns the predicate as a SQL expression string."""
 
-    @abstractmethod
-    def to_template(self) -> LiteralString:
-        """Returns the predicate as a parameterized SQL template string."""
-
-    def build_template(self, _counter: count[int]) -> tuple[LiteralString, dict[str, DataValue]]:
+    def build_template(self, _counter: count[int], _alias: str = "") -> tuple[LiteralString, dict[str, DataValue]]:
         """Builds a parameterized SQL template fragment using the shared parameter counter."""
         return "", {}
 
@@ -47,10 +43,6 @@ class Filter(Predicate):
 
     def to_expression(self) -> str:
         """Returns the filter as a SQL expression string."""
-        return ""
-
-    def to_template(self) -> LiteralString:
-        """Returns the filter as a parameterized SQL template string."""
         return ""
 
 
@@ -86,6 +78,18 @@ def _escape_like(value: DataValue) -> str:
     return str(value).replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
 
+def _clean_alias(alias: str) -> str:
+    """Strips whitespace and removes dots from a table alias."""
+    return alias.strip().replace(".", "")
+
+
+def _qualify(field_name: LiteralString, alias: str) -> str:
+    """Prepends a table alias to a field name when the alias is non-empty."""
+    if alias:
+        return f"{alias}.{field_name}"
+    return field_name
+
+
 class EqualFilter(Filter):
     """Filter for equality comparison (field = value)."""
 
@@ -103,10 +107,11 @@ class EqualFilter(Filter):
         """Returns the filter as a SQL expression string."""
         return f"{self.field_name} = {self.value}"
 
-    def build_template(self, counter: count[int]) -> tuple[LiteralString, dict[str, DataValue]]:
+    def build_template(self, counter: count[int], alias: str = "") -> tuple[LiteralString, dict[str, DataValue]]:
         """Builds a parameterized SQL template fragment using the shared parameter counter."""
         key = f"p{next(counter)}"
-        return f"{self.field_name} = %({key})s", {key: self._raw_value}
+        field = _qualify(self.field_name, alias)
+        return f"{field} = %({key})s", {key: self._raw_value}
 
 
 class NotEqualFilter(Filter):
@@ -126,10 +131,11 @@ class NotEqualFilter(Filter):
         """Returns the filter as a SQL expression string."""
         return f"{self.field_name} != {self.value}"
 
-    def build_template(self, counter: count[int]) -> tuple[LiteralString, dict[str, DataValue]]:
+    def build_template(self, counter: count[int], alias: str = "") -> tuple[LiteralString, dict[str, DataValue]]:
         """Builds a parameterized SQL template fragment using the shared parameter counter."""
         key = f"p{next(counter)}"
-        return f"{self.field_name} != %({key})s", {key: self._raw_value}
+        field = _qualify(self.field_name, alias)
+        return f"{field} != %({key})s", {key: self._raw_value}
 
 
 class LessThanFilter(Filter):
@@ -149,10 +155,11 @@ class LessThanFilter(Filter):
         """Returns the filter as a SQL expression string."""
         return f"{self.field_name} < {self.value}"
 
-    def build_template(self, counter: count[int]) -> tuple[LiteralString, dict[str, DataValue]]:
+    def build_template(self, counter: count[int], alias: str = "") -> tuple[LiteralString, dict[str, DataValue]]:
         """Builds a parameterized SQL template fragment using the shared parameter counter."""
         key = f"p{next(counter)}"
-        return f"{self.field_name} < %({key})s", {key: self._raw_value}
+        field = _qualify(self.field_name, alias)
+        return f"{field} < %({key})s", {key: self._raw_value}
 
 
 class LessThanOrEqualFilter(Filter):
@@ -172,10 +179,11 @@ class LessThanOrEqualFilter(Filter):
         """Returns the filter as a SQL expression string."""
         return f"{self.field_name} <= {self.value}"
 
-    def build_template(self, counter: count[int]) -> tuple[LiteralString, dict[str, DataValue]]:
+    def build_template(self, counter: count[int], alias: str = "") -> tuple[LiteralString, dict[str, DataValue]]:
         """Builds a parameterized SQL template fragment using the shared parameter counter."""
         key = f"p{next(counter)}"
-        return f"{self.field_name} <= %({key})s", {key: self._raw_value}
+        field = _qualify(self.field_name, alias)
+        return f"{field} <= %({key})s", {key: self._raw_value}
 
 
 class GreaterThanFilter(Filter):
@@ -195,10 +203,11 @@ class GreaterThanFilter(Filter):
         """Returns the filter as a SQL expression string."""
         return f"{self.field_name} > {self.value}"
 
-    def build_template(self, counter: count[int]) -> tuple[LiteralString, dict[str, DataValue]]:
+    def build_template(self, counter: count[int], alias: str = "") -> tuple[LiteralString, dict[str, DataValue]]:
         """Builds a parameterized SQL template fragment using the shared parameter counter."""
         key = f"p{next(counter)}"
-        return f"{self.field_name} > %({key})s", {key: self._raw_value}
+        field = _qualify(self.field_name, alias)
+        return f"{field} > %({key})s", {key: self._raw_value}
 
 
 class GreaterThanOrEqualFilter(Filter):
@@ -218,10 +227,11 @@ class GreaterThanOrEqualFilter(Filter):
         """Returns the filter as a SQL expression string."""
         return f"{self.field_name} >= {self.value}"
 
-    def build_template(self, counter: count[int]) -> tuple[LiteralString, dict[str, DataValue]]:
+    def build_template(self, counter: count[int], alias: str = "") -> tuple[LiteralString, dict[str, DataValue]]:
         """Builds a parameterized SQL template fragment using the shared parameter counter."""
         key = f"p{next(counter)}"
-        return f"{self.field_name} >= %({key})s", {key: self._raw_value}
+        field = _qualify(self.field_name, alias)
+        return f"{field} >= %({key})s", {key: self._raw_value}
 
 
 class InFilter(Filter):
@@ -241,8 +251,9 @@ class InFilter(Filter):
         """Returns the filter as a SQL expression string."""
         return f"{self.field_name} IN {self.values}"
 
-    def build_template(self, counter: count[int]) -> tuple[LiteralString, dict[str, DataValue]]:
+    def build_template(self, counter: count[int], alias: str = "") -> tuple[LiteralString, dict[str, DataValue]]:
         """Builds a parameterized SQL template fragment using the shared parameter counter."""
+        field = _qualify(self.field_name, alias)
         params: dict[str, DataValue] = {}
         placeholders: list[str] = []
         for val in self._raw_values:
@@ -250,7 +261,7 @@ class InFilter(Filter):
             params[key] = val
             placeholders.append(f"%({key})s")
         joined = ", ".join(placeholders)
-        return f"{self.field_name} IN ({joined})", params
+        return f"{field} IN ({joined})", params
 
 
 class NotInFilter(Filter):
@@ -270,8 +281,9 @@ class NotInFilter(Filter):
         """Returns the filter as a SQL expression string."""
         return f"{self.field_name} NOT IN {self.values}"
 
-    def build_template(self, counter: count[int]) -> tuple[LiteralString, dict[str, DataValue]]:
+    def build_template(self, counter: count[int], alias: str = "") -> tuple[LiteralString, dict[str, DataValue]]:
         """Builds a parameterized SQL template fragment using the shared parameter counter."""
+        field = _qualify(self.field_name, alias)
         params: dict[str, DataValue] = {}
         placeholders: list[str] = []
         for val in self._raw_values:
@@ -279,7 +291,7 @@ class NotInFilter(Filter):
             params[key] = val
             placeholders.append(f"%({key})s")
         joined = ", ".join(placeholders)
-        return f"{self.field_name} NOT IN ({joined})", params
+        return f"{field} NOT IN ({joined})", params
 
 
 class BetweenFilter(Filter):
@@ -306,12 +318,12 @@ class BetweenFilter(Filter):
         """Returns the filter as a SQL expression string."""
         return f"{self.field_name} BETWEEN {self.left} AND {self.right}"
 
-    def build_template(self, counter: count[int]) -> tuple[LiteralString, dict[str, DataValue]]:
+    def build_template(self, counter: count[int], alias: str = "") -> tuple[LiteralString, dict[str, DataValue]]:
         """Builds a parameterized SQL template fragment using the shared parameter counter."""
+        field = _qualify(self.field_name, alias)
         k1 = f"p{next(counter)}"
         k2 = f"p{next(counter)}"
-        return f"{self.field_name} BETWEEN %({k1})s AND %({k2})s", {k1: self._raw_left,
-                                                                    k2: self._raw_right}
+        return f"{field} BETWEEN %({k1})s AND %({k2})s", {k1: self._raw_left, k2: self._raw_right}
 
 
 class ContainsFilter(Filter):
@@ -319,23 +331,23 @@ class ContainsFilter(Filter):
 
     def __init__(self, field_name: str, value: DataValue) -> None:
         super().__init__(field_name)
-        self._value = format_value(value)
-        self._raw_value = value
+        self._value = value
 
     @property
-    def value(self) -> str:
-        """The formatted value to match against."""
+    def value(self) -> DataValue:
+        """The value to match against."""
         return self._value
 
     def to_expression(self) -> str:
         """Returns the filter as a SQL expression string."""
-        return f"{self.field_name} LIKE '%{self._raw_value}%'"
+        return f"{self.field_name} LIKE '%{self.value}%'"
 
-    def build_template(self, counter: count[int]) -> tuple[LiteralString, dict[str, DataValue]]:
+    def build_template(self, counter: count[int], alias: str = "") -> tuple[LiteralString, dict[str, DataValue]]:
         """Builds a parameterized SQL template fragment using the shared parameter counter."""
+        field = _qualify(self.field_name, alias)
         key = f"p{next(counter)}"
-        escaped = _escape_like(self._raw_value)
-        return f"{self.field_name} LIKE %({key})s", {key: f"%{escaped}%"}
+        escaped = _escape_like(self.value)
+        return f"{field} LIKE %({key})s", {key: f"%{escaped}%"}
 
 
 class NotContainsFilter(Filter):
@@ -343,23 +355,23 @@ class NotContainsFilter(Filter):
 
     def __init__(self, field_name: str, value: DataValue) -> None:
         super().__init__(field_name)
-        self._value = format_value(value)
-        self._raw_value = value
+        self._value = value
 
     @property
-    def value(self) -> str:
-        """The formatted value to match against."""
+    def value(self) -> DataValue:
+        """The value to match against."""
         return self._value
 
     def to_expression(self) -> str:
         """Returns the filter as a SQL expression string."""
-        return f"{self.field_name} NOT LIKE '%{self._raw_value}%'"
+        return f"{self.field_name} NOT LIKE '%{self.value}%'"
 
-    def build_template(self, counter: count[int]) -> tuple[LiteralString, dict[str, DataValue]]:
+    def build_template(self, counter: count[int], alias: str = "") -> tuple[LiteralString, dict[str, DataValue]]:
         """Builds a parameterized SQL template fragment using the shared parameter counter."""
+        field = _qualify(self.field_name, alias)
         key = f"p{next(counter)}"
-        escaped = _escape_like(self._raw_value)
-        return f"{self.field_name} NOT LIKE %({key})s", {key: f"%{escaped}%"}
+        escaped = _escape_like(self.value)
+        return f"{field} NOT LIKE %({key})s", {key: f"%{escaped}%"}
 
 
 class StartsWithFilter(Filter):
@@ -367,23 +379,23 @@ class StartsWithFilter(Filter):
 
     def __init__(self, field_name: str, value: DataValue) -> None:
         super().__init__(field_name)
-        self._value = format_value(value)
-        self._raw_value = value
+        self._value = value
 
     @property
-    def value(self) -> str:
-        """The formatted value to match against."""
+    def value(self) -> DataValue:
+        """The value to match against."""
         return self._value
 
     def to_expression(self) -> str:
         """Returns the filter as a SQL expression string."""
-        return f"{self.field_name} LIKE '{self._raw_value}%'"
+        return f"{self.field_name} LIKE '{self.value}%'"
 
-    def build_template(self, counter: count[int]) -> tuple[LiteralString, dict[str, DataValue]]:
+    def build_template(self, counter: count[int], alias: str = "") -> tuple[LiteralString, dict[str, DataValue]]:
         """Builds a parameterized SQL template fragment using the shared parameter counter."""
+        field = _qualify(self.field_name, alias)
         key = f"p{next(counter)}"
-        escaped = _escape_like(self._raw_value)
-        return f"{self.field_name} LIKE %({key})s", {key: f"{escaped}%"}
+        escaped = _escape_like(self.value)
+        return f"{field} LIKE %({key})s", {key: f"{escaped}%"}
 
 
 class EndsWithFilter(Filter):
@@ -391,23 +403,23 @@ class EndsWithFilter(Filter):
 
     def __init__(self, field_name: str, value: DataValue) -> None:
         super().__init__(field_name)
-        self._value = format_value(value)
-        self._raw_value = value
+        self._value = value
 
     @property
-    def value(self) -> str:
-        """The formatted value to match against."""
+    def value(self) -> DataValue:
+        """The value to match against."""
         return self._value
 
     def to_expression(self) -> str:
         """Returns the filter as a SQL expression string."""
-        return f"{self.field_name} LIKE '%{self._raw_value}'"
+        return f"{self.field_name} LIKE '%{self.value}'"
 
-    def build_template(self, counter: count[int]) -> tuple[LiteralString, dict[str, DataValue]]:
+    def build_template(self, counter: count[int], alias: str = "") -> tuple[LiteralString, dict[str, DataValue]]:
         """Builds a parameterized SQL template fragment using the shared parameter counter."""
+        field = _qualify(self.field_name, alias)
         key = f"p{next(counter)}"
-        escaped = _escape_like(self._raw_value)
-        return f"{self.field_name} LIKE %({key})s", {key: f"%{escaped}"}
+        escaped = _escape_like(self.value)
+        return f"{field} LIKE %({key})s", {key: f"%{escaped}"}
 
 
 class IsNullFilter(Filter):
@@ -420,9 +432,10 @@ class IsNullFilter(Filter):
         """Returns the filter as a SQL expression string."""
         return f"{self.field_name} IS NULL"
 
-    def build_template(self, _counter: count[int]) -> tuple[LiteralString, dict[str, DataValue]]:
+    def build_template(self, _counter: count[int], alias: str = "") -> tuple[LiteralString, dict[str, DataValue]]:
         """Builds a parameterized SQL template fragment using the shared parameter counter."""
-        return f"{self.field_name} IS NULL", {}
+        field = _qualify(self.field_name, alias)
+        return f"{field} IS NULL", {}
 
 
 class IsNotNullFilter(Filter):
@@ -435,9 +448,10 @@ class IsNotNullFilter(Filter):
         """Returns the filter as a SQL expression string."""
         return f"{self.field_name} IS NOT NULL"
 
-    def build_template(self, _counter: count[int]) -> tuple[LiteralString, dict[str, DataValue]]:
+    def build_template(self, _counter: count[int], alias: str = "") -> tuple[LiteralString, dict[str, DataValue]]:
         """Builds a parameterized SQL template fragment using the shared parameter counter."""
-        return f"{self.field_name} IS NOT NULL", {}
+        field = _qualify(self.field_name, alias)
+        return f"{field} IS NOT NULL", {}
 
 
 class Condition(Predicate):
@@ -450,15 +464,9 @@ class Condition(Predicate):
         """Returns the condition as a SQL expression string."""
         return self._filter.to_expression()
 
-    def to_template(self) -> LiteralString:
-        """Returns the condition as a parameterized SQL template string."""
-        counter = count()
-        template, _ = self._filter.build_template(counter)
-        return template
-
-    def build_template(self, counter: count[int]) -> tuple[LiteralString, dict[str, DataValue]]:
+    def build_template(self, counter: count[int], alias: str = "") -> tuple[LiteralString, dict[str, DataValue]]:
         """Builds a parameterized SQL template fragment using the shared parameter counter."""
-        return self._filter.build_template(counter)
+        return self._filter.build_template(counter, alias)
 
     @classmethod
     def equal(cls, field_name: str, value: DataValue) -> Condition:
@@ -553,11 +561,6 @@ class PredicateGroup(Predicate):
         """The predicates in this group."""
         return self._predicate
 
-    @property
-    def is_leaf_node(self) -> bool:
-        """Whether this group contains a single non-group predicate."""
-        return len(self._predicate) == 1 and not isinstance(self._predicate[0], PredicateGroup)
-
     def to_expression(self) -> str:
         """Returns the predicate group as a SQL expression string."""
         if not self.predicates:
@@ -574,13 +577,7 @@ class PredicateGroup(Predicate):
 
         return separator.join(expressions)
 
-    def to_template(self) -> LiteralString:
-        """Returns the predicate group as a parameterized SQL template string."""
-        counter = count()
-        template, _ = self.build_template(counter)
-        return template
-
-    def build_template(self, counter: count[int]) -> tuple[LiteralString, dict[str, DataValue]]:
+    def build_template(self, counter: count[int], alias: str = "") -> tuple[LiteralString, dict[str, DataValue]]:
         """Builds a parameterized SQL template fragment using the shared parameter counter."""
         if not self.predicates:
             return "", {}
@@ -588,7 +585,7 @@ class PredicateGroup(Predicate):
         templates: list[str] = []
         all_params: dict[str, DataValue] = {}
         for predicate in self.predicates:
-            tmpl, params = predicate.build_template(counter)
+            tmpl, params = predicate.build_template(counter, alias)
             if isinstance(predicate, PredicateGroup):
                 tmpl = f"({tmpl})"
             templates.append(tmpl)
@@ -671,15 +668,6 @@ class Specification(ABC):
     def to_expression(self) -> str:
         """Returns the specification as a SQL expression string."""
 
-    @abstractmethod
-    def to_template(self) -> LiteralString:
-        """Returns the specification as a parameterized SQL template string."""
-
-    @property
-    @abstractmethod
-    def parameters(self) -> Mapping[str, DataValue]:
-        """Returns the named parameters for the parameterized SQL template."""
-
     @property
     @abstractmethod
     def limit(self) -> int:
@@ -702,7 +690,6 @@ class QuerySpecification(Specification):
         self._predicate = predicate
         self._sorting = tuple(sorting) if sorting else ()
         self._pagination = pagination
-        self._cached_template: tuple[LiteralString, dict[str, DataValue]] | None = None
 
     @property
     def predicate(self) -> Predicate | None:
@@ -734,7 +721,9 @@ class QuerySpecification(Specification):
         parts: list[str] = []
 
         if self.predicate:
-            parts.append(f"WHERE {self.predicate.to_expression()}")
+            expr = self.predicate.to_expression()
+            if expr:
+                parts.append(f"WHERE {expr}")
 
         if self.sorting:
             sorting_expression = ", ".join(sort.to_expression() for sort in self.sorting)
@@ -744,34 +733,36 @@ class QuerySpecification(Specification):
 
         return " ".join(parts)
 
-    def to_template(self) -> LiteralString:
-        """Returns the full query specification as a parameterized SQL template string."""
-        template, _ = self._build_template()
-        return template
-
-    @property
-    def parameters(self) -> Mapping[str, DataValue]:
-        """Returns the named parameters for the parameterized SQL template."""
-        _, params = self._build_template()
-        return params
-
-    def _build_template(self) -> tuple[LiteralString, dict[str, DataValue]]:
-        if self._cached_template is not None:
-            return self._cached_template
-
+    def to_statement(self, alias: str = "") -> tuple[LiteralString, dict[str, DataValue]]:
+        """Returns the full query specification as a parameterized SQL statement."""
+        alias = _clean_alias(alias)
         parts: list[str] = []
         params: dict[str, DataValue] = {}
         counter = count()
 
         if self.predicate:
-            tmpl, params = self.predicate.build_template(counter)
-            parts.append(f"WHERE {tmpl}")
+            tmpl, params = self.predicate.build_template(counter, alias)
+            if tmpl:
+                parts.append(f"WHERE {tmpl}")
 
         if self.sorting:
-            sorting_expression = ", ".join(sort.to_expression() for sort in self.sorting)
+            sorting_expression = ", ".join(
+                f"{_qualify(sort.field_name, alias)} {sort.direction.value}" for sort in self.sorting
+            )
             parts.append(f"ORDER BY {sorting_expression}")
 
         parts.append(self.pagination.to_expression())
 
-        self._cached_template = " ".join(parts), params
-        return self._cached_template
+        return " ".join(parts), params
+
+    def to_filter(self, alias: str = "") -> tuple[LiteralString, dict[str, DataValue]]:
+        """Returns the filter predicate as a parameterized SQL WHERE clause."""
+        if not self.predicate:
+            return "", {}
+
+        alias = _clean_alias(alias)
+        counter = count()
+        tmpl, params = self.predicate.build_template(counter, alias)
+        if not tmpl:
+            return "", {}
+        return f"WHERE {tmpl}", params

--- a/tests/domain/specifications_test.py
+++ b/tests/domain/specifications_test.py
@@ -331,6 +331,19 @@ def test_specification_queries_with_country_in_do_us_pr():
     assert result == "WHERE country IN ('DO', 'US', 'PR') LIMIT 50 OFFSET 0"
 
 
+def test_specification_queries_with_status_not_in_inactive_archived():
+    # Arrange
+    predicate = Condition.not_in(field_name='status', values=['inactive', 'archived'])
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    result = specification.to_expression()
+
+    # Assert
+    assert result == "WHERE status NOT IN ('inactive', 'archived') LIMIT 50 OFFSET 0"
+
+
 def test_specification_queries_with_description_is_null():
     # Arrange
     predicate = Condition.is_null(field_name='description')
@@ -475,6 +488,57 @@ def test_specification_queries_with_position_sg_and_pts_gt_20_or_ast_gt_10():
     assert result == expected
 
 
+def test_specification_queries_with_and_groups_merged_by_same_operator():
+    # Arrange
+    group1 = PredicateGroup(operator=LogicalOperator.AND, predicates=[
+        Condition.equal(field_name='country', value='DO'),
+    ])
+    group2 = PredicateGroup(operator=LogicalOperator.AND, predicates=[
+        Condition.equal(field_name='status', value='active'),
+    ])
+    predicate = group1 & group2
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    result = specification.to_expression()
+
+    # Assert
+    assert result == "WHERE country = 'DO' AND status = 'active' LIMIT 50 OFFSET 0"
+
+
+def test_specification_queries_with_or_groups_merged_by_same_operator():
+    # Arrange
+    group1 = PredicateGroup(operator=LogicalOperator.OR, predicates=[
+        Condition.equal(field_name='country', value='DO'),
+    ])
+    group2 = PredicateGroup(operator=LogicalOperator.OR, predicates=[
+        Condition.equal(field_name='country', value='US'),
+    ])
+    predicate = group1 | group2
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    result = specification.to_expression()
+
+    # Assert
+    assert result == "WHERE country = 'DO' OR country = 'US' LIMIT 50 OFFSET 0"
+
+
+def test_specification_queries_with_empty_predicate_group():
+    # Arrange
+    predicate = PredicateGroup(operator=LogicalOperator.AND, predicates=[])
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    result = specification.to_expression()
+
+    # Assert
+    assert result == "LIMIT 50 OFFSET 0"
+
+
 def test_specification_queries_ordered_by_last_name_asc():
     # Arrange
     sorting = [SortOrder(field_name='last_name', direction=SortDirection.ASC)]
@@ -617,322 +681,301 @@ def test_specification_queries_with_country_do_ordered_by_last_name_asc_limit_10
     assert result == "WHERE country = 'DO' ORDER BY last_name ASC LIMIT 10 OFFSET 0"
 
 
-def test_specification_template_with_country_equal_do():
+def test_specification_statement_with_country_equal_do():
     # Arrange
     predicate = Condition.equal(field_name='country', value='DO')
     pagination = Pagination()
 
     # Act
     specification = QuerySpecification(predicate=predicate, pagination=pagination)
-    template = specification.to_template()
-    parameters = specification.parameters
+    template, parameters = specification.to_statement()
 
     # Assert
     assert template == "WHERE country = %(p0)s LIMIT 50 OFFSET 0"
     assert parameters == {'p0': 'DO'}
 
 
-def test_specification_template_with_active_equal_true():
+def test_specification_statement_with_active_equal_true():
     # Arrange
     predicate = Condition.equal(field_name='active', value=True)
     pagination = Pagination()
 
     # Act
     specification = QuerySpecification(predicate=predicate, pagination=pagination)
-    template = specification.to_template()
-    parameters = specification.parameters
+    template, parameters = specification.to_statement()
 
     # Assert
     assert template == "WHERE active = %(p0)s LIMIT 50 OFFSET 0"
     assert parameters == {'p0': True}
 
 
-def test_specification_template_with_status_not_equal_inactive():
+def test_specification_statement_with_status_not_equal_inactive():
     # Arrange
     predicate = Condition.not_equal(field_name='status', value='inactive')
     pagination = Pagination()
 
     # Act
     specification = QuerySpecification(predicate=predicate, pagination=pagination)
-    template = specification.to_template()
-    parameters = specification.parameters
+    template, parameters = specification.to_statement()
 
     # Assert
     assert template == "WHERE status != %(p0)s LIMIT 50 OFFSET 0"
     assert parameters == {'p0': 'inactive'}
 
 
-def test_specification_template_with_capacity_less_than_5000():
+def test_specification_statement_with_capacity_less_than_5000():
     # Arrange
     predicate = Condition.less_than(field_name='capacity', value=5000)
     pagination = Pagination()
 
     # Act
     specification = QuerySpecification(predicate=predicate, pagination=pagination)
-    template = specification.to_template()
-    parameters = specification.parameters
+    template, parameters = specification.to_statement()
 
     # Assert
     assert template == "WHERE capacity < %(p0)s LIMIT 50 OFFSET 0"
     assert parameters == {'p0': 5000}
 
 
-def test_specification_template_with_weight_less_than_or_equal_95_5():
+def test_specification_statement_with_weight_less_than_or_equal_95_5():
     # Arrange
     predicate = Condition.less_than_or_equal(field_name='weight', value=95.5)
     pagination = Pagination()
 
     # Act
     specification = QuerySpecification(predicate=predicate, pagination=pagination)
-    template = specification.to_template()
-    parameters = specification.parameters
+    template, parameters = specification.to_statement()
 
     # Assert
     assert template == "WHERE weight <= %(p0)s LIMIT 50 OFFSET 0"
     assert parameters == {'p0': 95.5}
 
 
-def test_specification_template_with_year_greater_than_2020():
+def test_specification_statement_with_year_greater_than_2020():
     # Arrange
     predicate = Condition.greater_than(field_name='year', value=2020)
     pagination = Pagination()
 
     # Act
     specification = QuerySpecification(predicate=predicate, pagination=pagination)
-    template = specification.to_template()
-    parameters = specification.parameters
+    template, parameters = specification.to_statement()
 
     # Assert
     assert template == "WHERE year > %(p0)s LIMIT 50 OFFSET 0"
     assert parameters == {'p0': 2020}
 
 
-def test_specification_template_with_capacity_greater_than_or_equal_5000():
+def test_specification_statement_with_capacity_greater_than_or_equal_5000():
     # Arrange
     predicate = Condition.greater_than_or_equal(field_name='capacity', value=5000)
     pagination = Pagination()
 
     # Act
     specification = QuerySpecification(predicate=predicate, pagination=pagination)
-    template = specification.to_template()
-    parameters = specification.parameters
+    template, parameters = specification.to_statement()
 
     # Assert
     assert template == "WHERE capacity >= %(p0)s LIMIT 50 OFFSET 0"
     assert parameters == {'p0': 5000}
 
 
-def test_specification_template_with_coach_id_equal_uuid():
+def test_specification_statement_with_coach_id_equal_uuid():
     # Arrange
     predicate = Condition.equal(field_name='coach_id', value=UUID('01926a3e-5b7c-7000-8000-000100000000'))
     pagination = Pagination()
 
     # Act
     specification = QuerySpecification(predicate=predicate, pagination=pagination)
-    template = specification.to_template()
-    parameters = specification.parameters
+    template, parameters = specification.to_statement()
 
     # Assert
     assert template == "WHERE coach_id = %(p0)s LIMIT 50 OFFSET 0"
     assert parameters == {'p0': UUID('01926a3e-5b7c-7000-8000-000100000000')}
 
 
-def test_specification_template_with_game_date_equal_datetime():
+def test_specification_statement_with_game_date_equal_datetime():
     # Arrange
     predicate = Condition.equal(field_name='game_date', value=datetime(2024, 6, 15, 19, 0, 0, tzinfo=UTC))
     pagination = Pagination()
 
     # Act
     specification = QuerySpecification(predicate=predicate, pagination=pagination)
-    template = specification.to_template()
-    parameters = specification.parameters
+    template, parameters = specification.to_statement()
 
     # Assert
     assert template == "WHERE game_date = %(p0)s LIMIT 50 OFFSET 0"
     assert parameters == {'p0': datetime(2024, 6, 15, 19, 0, 0, tzinfo=UTC)}
 
 
-def test_specification_template_with_country_in_do_us_pr():
+def test_specification_statement_with_country_in_do_us_pr():
     # Arrange
     predicate = Condition.is_in(field_name='country', values=['DO', 'US', 'PR'])
     pagination = Pagination()
 
     # Act
     specification = QuerySpecification(predicate=predicate, pagination=pagination)
-    template = specification.to_template()
-    parameters = specification.parameters
+    template, parameters = specification.to_statement()
 
     # Assert
     assert template == "WHERE country IN (%(p0)s, %(p1)s, %(p2)s) LIMIT 50 OFFSET 0"
     assert parameters == {'p0': 'DO', 'p1': 'US', 'p2': 'PR'}
 
 
-def test_specification_template_with_status_not_in_inactive_archived():
+def test_specification_statement_with_status_not_in_inactive_archived():
     # Arrange
     predicate = Condition.not_in(field_name='status', values=['inactive', 'archived'])
     pagination = Pagination()
 
     # Act
     specification = QuerySpecification(predicate=predicate, pagination=pagination)
-    template = specification.to_template()
-    parameters = specification.parameters
+    template, parameters = specification.to_statement()
 
     # Assert
     assert template == "WHERE status NOT IN (%(p0)s, %(p1)s) LIMIT 50 OFFSET 0"
     assert parameters == {'p0': 'inactive', 'p1': 'archived'}
 
 
-def test_specification_template_with_year_between_2024_and_2026():
+def test_specification_statement_with_year_between_2024_and_2026():
     # Arrange
     predicate = Condition.between(field_name='year', left=2024, right=2026)
     pagination = Pagination()
 
     # Act
     specification = QuerySpecification(predicate=predicate, pagination=pagination)
-    template = specification.to_template()
-    parameters = specification.parameters
+    template, parameters = specification.to_statement()
 
     # Assert
     assert template == "WHERE year BETWEEN %(p0)s AND %(p1)s LIMIT 50 OFFSET 0"
     assert parameters == {'p0': 2024, 'p1': 2026}
 
 
-def test_specification_template_with_slug_contains_garcia():
+def test_specification_statement_with_slug_contains_garcia():
     # Arrange
     predicate = Condition.contains(field_name='slug', value='garcia')
     pagination = Pagination()
 
     # Act
     specification = QuerySpecification(predicate=predicate, pagination=pagination)
-    template = specification.to_template()
-    parameters = specification.parameters
+    template, parameters = specification.to_statement()
 
     # Assert
     assert template == "WHERE slug LIKE %(p0)s LIMIT 50 OFFSET 0"
     assert parameters == {'p0': '%garcia%'}
 
 
-def test_specification_template_with_slug_not_contains_test():
+def test_specification_statement_with_slug_not_contains_test():
     # Arrange
     predicate = Condition.not_contains(field_name='slug', value='test')
     pagination = Pagination()
 
     # Act
     specification = QuerySpecification(predicate=predicate, pagination=pagination)
-    template = specification.to_template()
-    parameters = specification.parameters
+    template, parameters = specification.to_statement()
 
     # Assert
     assert template == "WHERE slug NOT LIKE %(p0)s LIMIT 50 OFFSET 0"
     assert parameters == {'p0': '%test%'}
 
 
-def test_specification_template_with_slug_starts_with_garcia():
+def test_specification_statement_with_slug_starts_with_garcia():
     # Arrange
     predicate = Condition.starts_with(field_name='slug', value='garcia')
     pagination = Pagination()
 
     # Act
     specification = QuerySpecification(predicate=predicate, pagination=pagination)
-    template = specification.to_template()
-    parameters = specification.parameters
+    template, parameters = specification.to_statement()
 
     # Assert
     assert template == "WHERE slug LIKE %(p0)s LIMIT 50 OFFSET 0"
     assert parameters == {'p0': 'garcia%'}
 
 
-def test_specification_template_with_slug_ends_with_jr():
+def test_specification_statement_with_slug_ends_with_jr():
     # Arrange
     predicate = Condition.ends_with(field_name='slug', value='jr')
     pagination = Pagination()
 
     # Act
     specification = QuerySpecification(predicate=predicate, pagination=pagination)
-    template = specification.to_template()
-    parameters = specification.parameters
+    template, parameters = specification.to_statement()
 
     # Assert
     assert template == "WHERE slug LIKE %(p0)s LIMIT 50 OFFSET 0"
     assert parameters == {'p0': '%jr'}
 
 
-def test_specification_template_with_label_contains_100_percent():
+def test_specification_statement_with_label_contains_100_percent():
     # Arrange
     predicate = Condition.contains(field_name='label', value='100%')
     pagination = Pagination()
 
     # Act
     specification = QuerySpecification(predicate=predicate, pagination=pagination)
-    template = specification.to_template()
-    parameters = specification.parameters
+    template, parameters = specification.to_statement()
 
     # Assert
     assert template == "WHERE label LIKE %(p0)s LIMIT 50 OFFSET 0"
     assert parameters == {'p0': '%100\\%%'}
 
 
-def test_specification_template_with_name_contains_under_score():
+def test_specification_statement_with_name_contains_under_score():
     # Arrange
     predicate = Condition.contains(field_name='name', value='user_name')
     pagination = Pagination()
 
     # Act
     specification = QuerySpecification(predicate=predicate, pagination=pagination)
-    template = specification.to_template()
-    parameters = specification.parameters
+    template, parameters = specification.to_statement()
 
     # Assert
     assert template == "WHERE name LIKE %(p0)s LIMIT 50 OFFSET 0"
     assert parameters == {'p0': '%user\\_name%'}
 
 
-def test_specification_template_with_label_starts_with_50_percent_off():
+def test_specification_statement_with_label_starts_with_50_percent_off():
     # Arrange
     predicate = Condition.starts_with(field_name='label', value='50% off')
     pagination = Pagination()
 
     # Act
     specification = QuerySpecification(predicate=predicate, pagination=pagination)
-    template = specification.to_template()
-    parameters = specification.parameters
+    template, parameters = specification.to_statement()
 
     # Assert
     assert template == "WHERE label LIKE %(p0)s LIMIT 50 OFFSET 0"
     assert parameters == {'p0': '50\\% off%'}
 
 
-def test_specification_template_with_description_is_null():
+def test_specification_statement_with_description_is_null():
     # Arrange
     predicate = Condition.is_null(field_name='description')
     pagination = Pagination()
 
     # Act
     specification = QuerySpecification(predicate=predicate, pagination=pagination)
-    template = specification.to_template()
-    parameters = specification.parameters
+    template, parameters = specification.to_statement()
 
     # Assert
     assert template == "WHERE description IS NULL LIMIT 50 OFFSET 0"
     assert parameters == {}
 
 
-def test_specification_template_with_headshot_url_is_not_null():
+def test_specification_statement_with_headshot_url_is_not_null():
     # Arrange
     predicate = Condition.is_not_null(field_name='headshot_url')
     pagination = Pagination()
 
     # Act
     specification = QuerySpecification(predicate=predicate, pagination=pagination)
-    template = specification.to_template()
-    parameters = specification.parameters
+    template, parameters = specification.to_statement()
 
     # Assert
     assert template == "WHERE headshot_url IS NOT NULL LIMIT 50 OFFSET 0"
     assert parameters == {}
 
 
-def test_specification_template_with_country_do_and_sex_male_and_status_active():
+def test_specification_statement_with_country_do_and_sex_male_and_status_active():
     # Arrange
     predicate = PredicateGroup(operator=LogicalOperator.AND, predicates=[
         Condition.equal(field_name='country', value='DO'),
@@ -943,15 +986,14 @@ def test_specification_template_with_country_do_and_sex_male_and_status_active()
 
     # Act
     specification = QuerySpecification(predicate=predicate, pagination=pagination)
-    template = specification.to_template()
-    parameters = specification.parameters
+    template, parameters = specification.to_statement()
 
     # Assert
     assert template == "WHERE country = %(p0)s AND sex = %(p1)s AND status = %(p2)s LIMIT 50 OFFSET 0"
     assert parameters == {'p0': 'DO', 'p1': 'male', 'p2': 'active'}
 
 
-def test_specification_template_with_last_name_contains_garcia_and_country_do():
+def test_specification_statement_with_last_name_contains_garcia_and_country_do():
     # Arrange
     predicate = PredicateGroup(operator=LogicalOperator.AND, predicates=[
         Condition.contains(field_name='last_name', value='garcia'),
@@ -961,15 +1003,14 @@ def test_specification_template_with_last_name_contains_garcia_and_country_do():
 
     # Act
     specification = QuerySpecification(predicate=predicate, pagination=pagination)
-    template = specification.to_template()
-    parameters = specification.parameters
+    template, parameters = specification.to_statement()
 
     # Assert
     assert template == "WHERE last_name LIKE %(p0)s AND country = %(p1)s LIMIT 50 OFFSET 0"
     assert parameters == {'p0': '%garcia%', 'p1': 'DO'}
 
 
-def test_specification_template_with_position_pg_or_pts_gt_20_and_ast_gt_10():
+def test_specification_statement_with_position_pg_or_pts_gt_20_and_ast_gt_10():
     # Arrange
     expression1 = PredicateGroup(operator=LogicalOperator.OR, predicates=[
         Condition.equal(field_name='position', value='PG'),
@@ -984,15 +1025,14 @@ def test_specification_template_with_position_pg_or_pts_gt_20_and_ast_gt_10():
 
     # Act
     specification = QuerySpecification(predicate=predicate, pagination=pagination)
-    template = specification.to_template()
-    parameters = specification.parameters
+    template, parameters = specification.to_statement()
 
     # Assert
     assert template == expected
     assert parameters == {'p0': 'PG', 'p1': 20, 'p2': 10}
 
 
-def test_specification_template_with_position_sg_and_pts_gt_20_or_ast_gt_10():
+def test_specification_statement_with_position_sg_and_pts_gt_20_or_ast_gt_10():
     # Arrange
     expression1 = PredicateGroup(operator=LogicalOperator.AND, predicates=[
         Condition.equal(field_name='position', value='SG'),
@@ -1007,15 +1047,14 @@ def test_specification_template_with_position_sg_and_pts_gt_20_or_ast_gt_10():
 
     # Act
     specification = QuerySpecification(predicate=predicate, pagination=pagination)
-    template = specification.to_template()
-    parameters = specification.parameters
+    template, parameters = specification.to_statement()
 
     # Assert
     assert template == expected
     assert parameters == {'p0': 'SG', 'p1': 20, 'p2': 10}
 
 
-def test_specification_template_with_country_do_ordered_by_last_name_asc_limit_10_offset_0():
+def test_specification_statement_with_country_do_ordered_by_last_name_asc_limit_10_offset_0():
     # Arrange
     predicate = Condition.equal(field_name='country', value='DO')
     sorting = [SortOrder(field_name='last_name', direction=SortDirection.ASC)]
@@ -1023,26 +1062,482 @@ def test_specification_template_with_country_do_ordered_by_last_name_asc_limit_1
 
     # Act
     specification = QuerySpecification(predicate=predicate, sorting=sorting, pagination=pagination)
-    template = specification.to_template()
-    parameters = specification.parameters
+    template, parameters = specification.to_statement()
 
     # Assert
     assert template == "WHERE country = %(p0)s ORDER BY last_name ASC LIMIT 10 OFFSET 0"
     assert parameters == {'p0': 'DO'}
 
 
-def test_specification_template_with_no_predicate_limit_25_offset_10():
+def test_specification_statement_with_no_predicate_limit_25_offset_10():
     # Arrange
     pagination = Pagination(limit=25, offset=10)
 
     # Act
     specification = QuerySpecification(pagination=pagination)
-    template = specification.to_template()
-    parameters = specification.parameters
+    template, parameters = specification.to_statement()
 
     # Assert
     assert template == "LIMIT 25 OFFSET 10"
     assert parameters == {}
+
+
+def test_specification_statement_with_and_groups_merged_by_same_operator():
+    # Arrange
+    group1 = PredicateGroup(operator=LogicalOperator.AND, predicates=[
+        Condition.equal(field_name='country', value='DO'),
+    ])
+    group2 = PredicateGroup(operator=LogicalOperator.AND, predicates=[
+        Condition.equal(field_name='status', value='active'),
+    ])
+    predicate = group1 & group2
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template, parameters = specification.to_statement()
+
+    # Assert
+    assert template == "WHERE country = %(p0)s AND status = %(p1)s LIMIT 50 OFFSET 0"
+    assert parameters == {'p0': 'DO', 'p1': 'active'}
+
+
+def test_specification_statement_with_or_groups_merged_by_same_operator():
+    # Arrange
+    group1 = PredicateGroup(operator=LogicalOperator.OR, predicates=[
+        Condition.equal(field_name='country', value='DO'),
+    ])
+    group2 = PredicateGroup(operator=LogicalOperator.OR, predicates=[
+        Condition.equal(field_name='country', value='US'),
+    ])
+    predicate = group1 | group2
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template, parameters = specification.to_statement()
+
+    # Assert
+    assert template == "WHERE country = %(p0)s OR country = %(p1)s LIMIT 50 OFFSET 0"
+    assert parameters == {'p0': 'DO', 'p1': 'US'}
+
+
+def test_specification_statement_with_empty_predicate_group():
+    # Arrange
+    predicate = PredicateGroup(operator=LogicalOperator.AND, predicates=[])
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template, parameters = specification.to_statement()
+
+    # Assert
+    assert template == "LIMIT 50 OFFSET 0"
+    assert parameters == {}
+
+
+def test_specification_statement_with_alias_prepends_to_field_name():
+    # Arrange
+    predicate = Condition.equal(field_name='country', value='DO')
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template, parameters = specification.to_statement(alias='t')
+
+    # Assert
+    assert template == "WHERE t.country = %(p0)s LIMIT 50 OFFSET 0"
+    assert parameters == {'p0': 'DO'}
+
+
+def test_specification_statement_with_alias_prepends_to_sort_order():
+    # Arrange
+    sorting = [SortOrder(field_name='last_name', direction=SortDirection.ASC)]
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(sorting=sorting, pagination=pagination)
+    template, parameters = specification.to_statement(alias='t')
+
+    # Assert
+    assert template == "ORDER BY t.last_name ASC LIMIT 50 OFFSET 0"
+    assert parameters == {}
+
+
+def test_specification_statement_with_alias_and_predicate_and_sorting():
+    # Arrange
+    predicate = Condition.equal(field_name='country', value='DO')
+    sorting = [SortOrder(field_name='last_name', direction=SortDirection.ASC)]
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, sorting=sorting, pagination=pagination)
+    template, parameters = specification.to_statement(alias='p')
+
+    # Assert
+    assert template == "WHERE p.country = %(p0)s ORDER BY p.last_name ASC LIMIT 50 OFFSET 0"
+    assert parameters == {'p0': 'DO'}
+
+
+def test_specification_statement_with_alias_and_predicate_group():
+    # Arrange
+    predicate = PredicateGroup(operator=LogicalOperator.AND, predicates=[
+        Condition.equal(field_name='country', value='DO'),
+        Condition.equal(field_name='status', value='active'),
+    ])
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template, parameters = specification.to_statement(alias='t')
+
+    # Assert
+    assert template == "WHERE t.country = %(p0)s AND t.status = %(p1)s LIMIT 50 OFFSET 0"
+    assert parameters == {'p0': 'DO', 'p1': 'active'}
+
+
+def test_specification_statement_with_alias_and_in_filter():
+    # Arrange
+    predicate = Condition.is_in(field_name='country', values=['DO', 'US'])
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template, parameters = specification.to_statement(alias='t')
+
+    # Assert
+    assert template == "WHERE t.country IN (%(p0)s, %(p1)s) LIMIT 50 OFFSET 0"
+    assert parameters == {'p0': 'DO', 'p1': 'US'}
+
+
+def test_specification_statement_with_alias_and_is_null_filter():
+    # Arrange
+    predicate = Condition.is_null(field_name='description')
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template, parameters = specification.to_statement(alias='t')
+
+    # Assert
+    assert template == "WHERE t.description IS NULL LIMIT 50 OFFSET 0"
+    assert parameters == {}
+
+
+def test_specification_statement_with_alias_and_like_filter():
+    # Arrange
+    predicate = Condition.contains(field_name='slug', value='garcia')
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template, parameters = specification.to_statement(alias='t')
+
+    # Assert
+    assert template == "WHERE t.slug LIKE %(p0)s LIMIT 50 OFFSET 0"
+    assert parameters == {'p0': '%garcia%'}
+
+
+def test_specification_statement_with_alias_and_between_filter():
+    # Arrange
+    predicate = Condition.between(field_name='year', left=2024, right=2026)
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template, parameters = specification.to_statement(alias='t')
+
+    # Assert
+    assert template == "WHERE t.year BETWEEN %(p0)s AND %(p1)s LIMIT 50 OFFSET 0"
+    assert parameters == {'p0': 2024, 'p1': 2026}
+
+
+def test_specification_statement_with_alias_and_mixed_operator_group():
+    # Arrange
+    expression1 = PredicateGroup(operator=LogicalOperator.OR, predicates=[
+        Condition.equal(field_name='position', value='PG'),
+    ])
+    expression2 = PredicateGroup(operator=LogicalOperator.AND, predicates=[
+        Condition.greater_than(field_name='pts', value=20),
+        Condition.greater_than(field_name='ast', value=10),
+    ])
+    predicate = expression1 | expression2
+    pagination = Pagination()
+    expected = "WHERE (t.position = %(p0)s) OR (t.pts > %(p1)s AND t.ast > %(p2)s) LIMIT 50 OFFSET 0"
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template, parameters = specification.to_statement(alias='t')
+
+    # Assert
+    assert template == expected
+    assert parameters == {'p0': 'PG', 'p1': 20, 'p2': 10}
+
+
+def test_specification_statement_with_empty_alias_no_prefix():
+    # Arrange
+    predicate = Condition.equal(field_name='country', value='DO')
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template, parameters = specification.to_statement(alias='')
+
+    # Assert
+    assert template == "WHERE country = %(p0)s LIMIT 50 OFFSET 0"
+    assert parameters == {'p0': 'DO'}
+
+
+def test_specification_statement_with_whitespace_alias_no_prefix():
+    # Arrange
+    predicate = Condition.equal(field_name='country', value='DO')
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template, parameters = specification.to_statement(alias='  ')
+
+    # Assert
+    assert template == "WHERE country = %(p0)s LIMIT 50 OFFSET 0"
+    assert parameters == {'p0': 'DO'}
+
+
+def test_specification_statement_with_alias_dots_stripped():
+    # Arrange
+    predicate = Condition.equal(field_name='country', value='DO')
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template, parameters = specification.to_statement(alias='t.')
+
+    # Assert
+    assert template == "WHERE t.country = %(p0)s LIMIT 50 OFFSET 0"
+    assert parameters == {'p0': 'DO'}
+
+
+def test_specification_statement_with_alias_whitespace_and_dots_stripped():
+    # Arrange
+    predicate = Condition.equal(field_name='country', value='DO')
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template, parameters = specification.to_statement(alias=' t. ')
+
+    # Assert
+    assert template == "WHERE t.country = %(p0)s LIMIT 50 OFFSET 0"
+    assert parameters == {'p0': 'DO'}
+
+
+def test_specification_filter_with_country_equal_do():
+    # Arrange
+    predicate = Condition.equal(field_name='country', value='DO')
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template, parameters = specification.to_filter()
+
+    # Assert
+    assert template == "WHERE country = %(p0)s"
+    assert parameters == {'p0': 'DO'}
+
+
+def test_specification_filter_with_status_not_equal_inactive():
+    # Arrange
+    predicate = Condition.not_equal(field_name='status', value='inactive')
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template, parameters = specification.to_filter()
+
+    # Assert
+    assert template == "WHERE status != %(p0)s"
+    assert parameters == {'p0': 'inactive'}
+
+
+def test_specification_filter_with_capacity_less_than_5000():
+    # Arrange
+    predicate = Condition.less_than(field_name='capacity', value=5000)
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template, parameters = specification.to_filter()
+
+    # Assert
+    assert template == "WHERE capacity < %(p0)s"
+    assert parameters == {'p0': 5000}
+
+
+def test_specification_filter_with_country_in_do_us_pr():
+    # Arrange
+    predicate = Condition.is_in(field_name='country', values=['DO', 'US', 'PR'])
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template, parameters = specification.to_filter()
+
+    # Assert
+    assert template == "WHERE country IN (%(p0)s, %(p1)s, %(p2)s)"
+    assert parameters == {'p0': 'DO', 'p1': 'US', 'p2': 'PR'}
+
+
+def test_specification_filter_with_description_is_null():
+    # Arrange
+    predicate = Condition.is_null(field_name='description')
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template, parameters = specification.to_filter()
+
+    # Assert
+    assert template == "WHERE description IS NULL"
+    assert parameters == {}
+
+
+def test_specification_filter_with_slug_contains_garcia():
+    # Arrange
+    predicate = Condition.contains(field_name='slug', value='garcia')
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template, parameters = specification.to_filter()
+
+    # Assert
+    assert template == "WHERE slug LIKE %(p0)s"
+    assert parameters == {'p0': '%garcia%'}
+
+
+def test_specification_filter_ignores_sorting_and_pagination():
+    # Arrange
+    predicate = Condition.equal(field_name='country', value='DO')
+    sorting = [SortOrder(field_name='last_name', direction=SortDirection.ASC)]
+    pagination = Pagination(limit=10, offset=0)
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, sorting=sorting, pagination=pagination)
+    template, parameters = specification.to_filter()
+
+    # Assert
+    assert template == "WHERE country = %(p0)s"
+    assert parameters == {'p0': 'DO'}
+
+
+def test_specification_filter_with_no_predicate():
+    # Arrange
+    pagination = Pagination(limit=25, offset=10)
+
+    # Act
+    specification = QuerySpecification(pagination=pagination)
+    template, parameters = specification.to_filter()
+
+    # Assert
+    assert template == ""
+    assert parameters == {}
+
+
+def test_specification_filter_with_country_do_and_status_active():
+    # Arrange
+    predicate = PredicateGroup(operator=LogicalOperator.AND, predicates=[
+        Condition.equal(field_name='country', value='DO'),
+        Condition.equal(field_name='status', value='active'),
+    ])
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template, parameters = specification.to_filter()
+
+    # Assert
+    assert template == "WHERE country = %(p0)s AND status = %(p1)s"
+    assert parameters == {'p0': 'DO', 'p1': 'active'}
+
+
+def test_specification_filter_with_mixed_operators():
+    # Arrange
+    expression1 = PredicateGroup(operator=LogicalOperator.OR, predicates=[
+        Condition.equal(field_name='position', value='PG'),
+    ])
+    expression2 = PredicateGroup(operator=LogicalOperator.AND, predicates=[
+        Condition.greater_than(field_name='pts', value=20),
+        Condition.greater_than(field_name='ast', value=10),
+    ])
+    predicate = expression1 | expression2
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template, parameters = specification.to_filter()
+
+    # Assert
+    assert template == "WHERE (position = %(p0)s) OR (pts > %(p1)s AND ast > %(p2)s)"
+    assert parameters == {'p0': 'PG', 'p1': 20, 'p2': 10}
+
+
+def test_specification_filter_with_alias_prepends_to_field_name():
+    # Arrange
+    predicate = Condition.equal(field_name='country', value='DO')
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template, parameters = specification.to_filter(alias='t')
+
+    # Assert
+    assert template == "WHERE t.country = %(p0)s"
+    assert parameters == {'p0': 'DO'}
+
+
+def test_specification_filter_with_alias_and_predicate_group():
+    # Arrange
+    predicate = PredicateGroup(operator=LogicalOperator.AND, predicates=[
+        Condition.equal(field_name='country', value='DO'),
+        Condition.greater_than(field_name='pts', value=20),
+    ])
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template, parameters = specification.to_filter(alias='t')
+
+    # Assert
+    assert template == "WHERE t.country = %(p0)s AND t.pts > %(p1)s"
+    assert parameters == {'p0': 'DO', 'p1': 20}
+
+
+def test_specification_filter_with_alias_ignores_sorting_and_pagination():
+    # Arrange
+    predicate = Condition.equal(field_name='country', value='DO')
+    sorting = [SortOrder(field_name='last_name', direction=SortDirection.ASC)]
+    pagination = Pagination(limit=10, offset=0)
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, sorting=sorting, pagination=pagination)
+    template, parameters = specification.to_filter(alias='p')
+
+    # Assert
+    assert template == "WHERE p.country = %(p0)s"
+    assert parameters == {'p0': 'DO'}
+
+
+def test_specification_filter_with_empty_alias_no_prefix():
+    # Arrange
+    predicate = Condition.equal(field_name='country', value='DO')
+    pagination = Pagination()
+
+    # Act
+    specification = QuerySpecification(predicate=predicate, pagination=pagination)
+    template, parameters = specification.to_filter(alias='')
+
+    # Assert
+    assert template == "WHERE country = %(p0)s"
+    assert parameters == {'p0': 'DO'}
 
 
 def test_specification_limit_delegates_to_pagination():


### PR DESCRIPTION
## Summary

The v7.2.0 release (issue #124) deviated from the original design request for parameterized SQL output on `QuerySpecification`. This PR realigns the API with the intent of the issue, adds a new feature, and cleans up dead code.

### What changed and why

**API realignment — `to_statement()` replaces `to_template()` + `parameters`**

Issue #124 asked for a single method returning a `(template, params)` tuple. The v7.2.0 implementation split this into separate `to_template()` and `parameters` property, which diverges from the consumer pattern (`cursor.execute(sql, params)` takes both together). The new `to_statement()` returns the tuple directly:

```python
sql, params = specification.to_statement()
# sql    → "WHERE country = %(p0)s ORDER BY last_name ASC LIMIT 10 OFFSET 0"
# params → {'p0': 'DO'}
```

**New method — `to_filter()`**

Returns the same `(template, params)` tuple but only the WHERE clause, without ORDER BY or pagination. Useful when the consumer needs to combine the filter with a custom query:

```python
sql, params = specification.to_filter()
# sql    → "WHERE country = %(p0)s"
# params → {'p0': 'DO'}
```

**New parameter — `alias` on `to_statement()` and `to_filter()`**

Qualifies field names with a table alias for use in JOINs or subqueries. The alias is cleaned (stripped, dots removed) before use:

```python
sql, params = specification.to_statement(alias='t')
# sql    → "WHERE t.country = %(p0)s ORDER BY t.last_name ASC LIMIT 10 OFFSET 0"
```

**Removed from `Specification` ABC** — `to_template()`, `parameters` (not part of the abstract contract; `limit`/`offset` kept).

**Removed from `Predicate` hierarchy** — standalone `to_template()` on `Predicate`, `Filter`, `Condition`, `PredicateGroup` (unrequested extras).

**Removed** — `_cached_template` (marginal value), `PredicateGroup.is_leaf_node` (dead code since creation).

**Simplified LIKE filters** — `ContainsFilter`, `NotContainsFilter`, `StartsWithFilter`, `EndsWithFilter` no longer call `format_value()`. They store the raw value directly since both `to_expression()` and `build_template()` need the unformatted value, not the SQL-quoted form.

### Coverage

- Tests: 267 (up from 233), including 33 net-new tests for `to_statement()`, `to_filter()`, alias behavior, and previously uncovered `PredicateGroup` branches
- Coverage: 99% on `specifications.py` (4 remaining lines are base class stubs and edge guards)
- mypy: clean
- ruff: clean

## Test plan

- [x] All 267 tests pass via `uv run tox -e py312`
- [x] Coverage at 99% via `uv run tox -e coverage`
- [x] mypy passes with no issues
- [x] ruff passes with no lint violations
- [x] Existing `to_expression()` tests unchanged and passing
- [x] New `to_statement()` tests cover all filter types, predicate groups, mixed operators, and pagination
- [x] New `to_filter()` tests verify WHERE-only output and that sorting/pagination are excluded
- [x] Alias tests verify field qualification, cleaning (whitespace/dots), and propagation through nested groups
- [x] Coverage gap tests exercise `PredicateGroup.__and__`/`__or__` same-operator merge and empty predicate groups

🤖 Generated with [Claude Code](https://claude.com/claude-code)