### PR TITLE
chore: Bump version to 8.0.0 and update changelog and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to Shared Kernel will be documented in this file.
 
+## 8.0.0 (2026-05-25)
+
+### Added
+
+- `to_statement(alias="")` method on `QuerySpecification` returning a parameterized SQL fragment with named placeholders.
+- `to_filter(alias="")` method on `QuerySpecification` for filter-clause extraction.
+- Optional `alias` parameter on `Filter.build_template` for qualifying field names with a table alias.
+
+### Removed
+
+- `to_template()` method on `Specification`, `Predicate`, `Filter`, `Condition`, `PredicateGroup`, and `QuerySpecification`. **BREAKING** — use `QuerySpecification.to_statement()` instead.
+- `parameters` abstract property on `Specification` (and its `QuerySpecification` implementation). **BREAKING** — parameters are now returned as part of the `to_statement()` result.
+- `PredicateGroup.is_leaf_node` property. **BREAKING**
+- Internal `QuerySpecification._cached_template` (template cache removed alongside the API change).
+
+### Changed
+
+- Persistence how-to guide updated to demonstrate `to_statement()` and `to_filter()` usage.
+
 ## 7.2.0 (2026-05-21)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Shared Kernel is built using Python 3.12 and depends on the follow libraries:
 To install Share Kernel using pip, run:
 
 ```shell
-pip install git+https://github.com/juanluiscr27/shared-kernel.git@v7.2.0#egg=sharedkernel
+pip install git+https://github.com/juanluiscr27/shared-kernel.git@v8.0.0#egg=sharedkernel
 ```
 
 ## Usage

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ maintaining clean boundaries.
 ### Installation
 
 ```bash
-pip install git+https://github.com/juanluiscr27/shared-kernel.git@v7.2.0#egg=sharedkernel
+pip install git+https://github.com/juanluiscr27/shared-kernel.git@v8.0.0#egg=sharedkernel
 ```
 
 ### Basic Example: Value Objects

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sharedkernel"
-version = "7.2.0"
+version = "8.0.0"
 description = "Shared Kernel for clean architecture projects"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -428,7 +428,7 @@ wheels = [
 
 [[package]]
 name = "sharedkernel"
-version = "7.2.0"
+version = "8.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

Prepares the `v8.0.0` release covering the two commits landed on `main` since `v7.2.0`:

- `05ec54b` refactor: Realign Specification parameterized API with original design
- `d6336ef` docs: Update persistence guide with `to_statement` and `to_filter` usage

The realignment removes the `to_template()` method and `parameters` property introduced in `7.2.0` (on `Specification`, `Predicate`, `Filter`, `Condition`, `PredicateGroup`, `QuerySpecification`) and replaces them with `to_statement()` / `to_filter()` on `QuerySpecification`, plus an optional `alias` parameter on `Filter.build_template`. Removing public API is a breaking change under semver and matches this project's convention of bumping the major version for breaking releases — hence `8.0.0` rather than a minor bump.

## Changes

- `pyproject.toml` — version `7.2.0` → `8.0.0`
- `README.md`, `docs/index.md` — installation example pinned to `v8.0.0`
- `uv.lock` — regenerated (`sharedkernel==8.0.0`)
- `CHANGELOG.md` — new `## 8.0.0 (2026-05-25)` section with **BREAKING** markers on the removed API

## Test plan

- [x] `uv run ruff check .` — passes
- [x] `uv run mypy sharedkernel/` — 30 files, no issues
- [x] `uv run tox -e py312` — 267 tests pass
- [ ] After merge: tag `v8.0.0` on `main` and push to trigger `.github/workflows/release.yaml`

https://claude.ai/code/session_01JVexsBdfjgrTni9QteYeXr