### PR TITLE
fix: Declare to_statement and to_filter on Specification base

### DIFF
--- a/sharedkernel/domain/specifications.py
+++ b/sharedkernel/domain/specifications.py
@@ -668,6 +668,14 @@ class Specification(ABC):
     def to_expression(self) -> str:
         """Returns the specification as a SQL expression string."""
 
+    @abstractmethod
+    def to_statement(self, alias: str = "") -> tuple[LiteralString, dict[str, DataValue]]:
+        """Returns the full query specification as a parameterized SQL statement."""
+
+    @abstractmethod
+    def to_filter(self, alias: str = "") -> tuple[LiteralString, dict[str, DataValue]]:
+        """Returns the filter predicate as a parameterized SQL WHERE clause."""
+
     @property
     @abstractmethod
     def limit(self) -> int:


### PR DESCRIPTION
## Summary

Adds `to_statement` and `to_filter` as `@abstractmethod` declarations on the `Specification` abstract base class. Previously these methods existed only on the concrete `QuerySpecification`, so code holding a `Specification`-typed reference (e.g. `ReadRepository.find_all(specification: Specification)`) failed mypy with:

```
"Specification" has no attribute "to_filter"    [attr-defined]
"Specification" has no attribute "to_statement" [attr-defined]
```

`QuerySpecification` already implements both methods with matching signatures, so it continues to satisfy the contract with no other changes. It is the only subclass of `Specification` in the repo.

## Verification

- `uv run mypy sharedkernel/` — no issues found in 30 source files
- `uv run ruff check .` — all checks passed
- `uv run tox -e py312` — 267 passed

Closes #130