### PR TITLE
fix: Forward emitter stream_id through EventBroker.publish

### DIFF
--- a/sharedkernel/domain/events.py
+++ b/sharedkernel/domain/events.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from uuid import UUID
 
 
 @dataclass(frozen=True)
@@ -24,12 +25,13 @@ class DomainEventHandler[TEvent: DomainEvent](ABC):
     """
 
     @abstractmethod
-    def process(self, event: TEvent, position: int) -> None:
+    def process(self, event: TEvent, position: int, stream_id: UUID) -> None:
         """Process a Domain Event.
 
         Args:
             event: Domain Event to process.
             position: Event position in the Stream
+            stream_id: Identifier of the emitter aggregate stream.
 
         Returns:
             None

--- a/sharedkernel/infrastructure/services.py
+++ b/sharedkernel/infrastructure/services.py
@@ -123,7 +123,7 @@ class EventBroker:
         token = set_request_id(event.correlation_id)
         try:
             for consumer in consumer_group:
-                consumer.process(domain_event, event.position)
+                consumer.process(domain_event, event.position, event.stream_id)
         finally:
             reset_request_id(token)
 

--- a/tests/application/service_bus_test.py
+++ b/tests/application/service_bus_test.py
@@ -132,7 +132,7 @@ class UserRegistered(DomainEvent):
 
 class RegistrationEventHandler(DomainEventHandler[UserRegistered]):
 
-    def process(self, event: UserRegistered, position: int):
+    def process(self, event: UserRegistered, position: int, stream_id: UUID):
         pass
 
 

--- a/tests/infrastructure/event_broker_test.py
+++ b/tests/infrastructure/event_broker_test.py
@@ -34,20 +34,29 @@ class UserLoggedIn(DomainEvent):
 
 class RegistrationEventHandler(DomainEventHandler[UserRegistered]):
 
-    def process(self, event: UserRegistered, position: int):
+    def process(self, event: UserRegistered, position: int, stream_id: UUID):
         print(f"{event.event_id} event processed by {type(self).__name__}")
 
 
 class EmailUserEventHandler(DomainEventHandler[UserRegistered]):
 
-    def process(self, event: UserRegistered, position: int):
+    def process(self, event: UserRegistered, position: int, stream_id: UUID):
         print(f"{event.event_id} event processed by {type(self).__name__}")
 
 
 class ContextAwareEventHandler(DomainEventHandler[UserRegistered]):
 
-    def process(self, event: UserRegistered, position: int):
+    def process(self, event: UserRegistered, position: int, stream_id: UUID):
         print(f"{event.event_id} event processed with request_id={get_request_id()}")
+
+
+class RecordingEventHandler(DomainEventHandler[UserRegistered]):
+
+    def __init__(self):
+        self.received: list[tuple[int, UUID]] = []
+
+    def process(self, event: UserRegistered, position: int, stream_id: UUID):
+        self.received.append((position, stream_id))
 
 
 class RegisterUserCommandHandler(CommandHandler[RegisterUser]):
@@ -223,6 +232,47 @@ def test_event_handler_sees_correct_request_id_when_event_is_published(fake_logg
 
     # Assert
     assert capture_stdout["console"] == console
+
+
+def test_events_from_different_streams_with_same_position_are_both_processed(fake_logger):
+    # Arrange
+    event_handler = RecordingEventHandler()
+    fake_mapper = FakeDomainEventMapper()
+    event_broker = EventBroker(fake_logger, fake_mapper)
+    event_broker.subscribe(event_handler)
+
+    first_stream_id = UUID("018f9284-769b-726d-b3bf-3885bf2ddd3c")
+    second_stream_id = UUID("018f9284-769b-726d-b3bf-3885bf2ddd3d")
+
+    first_event = Event(
+        event_id=UUID("018f55de-8321-7efd-a4e3-fcc2c5ec5eea"),
+        event_type="UserRegistered",
+        position=1,
+        data='{"event_id":"UserRegistered", "message":"User(name=\'John Doe\')"}',
+        stream_id=first_stream_id,
+        stream_type="User",
+        version=1,
+        created=datetime.fromisoformat('2024-04-28T12:30:12-04:00'),
+        correlation_id=UUID('018fa862-800b-7b6a-8690-ba0e06908c26'),
+    )
+    second_event = Event(
+        event_id=UUID("018f55de-8321-7efd-a4e3-fcc2c5ec5eeb"),
+        event_type="UserRegistered",
+        position=1,
+        data='{"event_id":"UserRegistered", "message":"User(name=\'Jane Doe\')"}',
+        stream_id=second_stream_id,
+        stream_type="User",
+        version=1,
+        created=datetime.fromisoformat('2024-04-28T12:30:12-04:00'),
+        correlation_id=UUID('018fa862-800b-7b6a-8690-ba0e06908c26'),
+    )
+
+    # Act
+    event_broker.publish(first_event)
+    event_broker.publish(second_event)
+
+    # Assert
+    assert event_handler.received == [(1, first_stream_id), (1, second_stream_id)]
 
 
 def test_request_id_is_reset_after_event_processing(fake_logger):


### PR DESCRIPTION
Closes #131

## Summary

`EventBroker.publish` notified each subscribed `DomainEventHandler` with only `(domain_event, position)`, omitting the emitter's `stream_id` — unlike `EventDispatcher.dispatch`, which already passes `(domain_event, position, stream_id)` to projectors. Because `position` is a per-`(stream_id, event_type)` counter (always starting at `1` per stream), saga handlers could not reliably key their inbox on the emitter, so same-position events originating from different source streams were silently dropped as duplicates.

This is the framework-level root cause of downstream bug juanluiscr27/basquetboldata-admin#826.

## Changes

- `DomainEventHandler.process` now accepts the emitter `stream_id` as a third argument (`sharedkernel/domain/events.py`). **BREAKING** for every consumer that subclasses it.
- `EventBroker.publish` forwards `event.stream_id`, mirroring `EventDispatcher.dispatch` (`sharedkernel/infrastructure/services.py`).
- Updated in-repo handler doubles to the new signature (`tests/infrastructure/event_broker_test.py`, `tests/application/service_bus_test.py`).
- Added a regression test: two events with the same `event_type` and same `position` but different `stream_id` are **both** dispatched (neither skipped).

## Scope

- Forwards `stream_id` only; `stream_type` forwarding (optional in the issue) is out of scope.
- Projector path is unchanged — it already passes and consumes `stream_id`.
- No version bump or changelog change included.

## Verification

- `uv run tox -e py312` — 268 passed
- `uv run ruff check .` — all checks passed
- `uv run mypy sharedkernel/` — no issues