### PR TITLE
chore: Release 9.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Shared Kernel will be documented in this file.
 
+## 9.0.0 (2026-07-03)
+
+### Changed
+
+- `DomainEventHandler.process` now takes a third `stream_id: UUID` argument, and `EventBroker.publish` forwards the emitter `stream_id` (mirroring the projector path) so saga/inbox handlers can key their inbox on the source stream. **BREAKING** — update every `DomainEventHandler.process` override to the new signature. (#131)
+
+### Added
+
+- `to_statement(alias="")` and `to_filter(alias="")` declared as abstract methods on the `Specification` base class (already implemented by `QuerySpecification`). **BREAKING** — direct `Specification` subclasses must now implement both. (#130)
+
 ## 8.0.0 (2026-05-25)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Shared Kernel is built using Python 3.12 and depends on the follow libraries:
 To install Share Kernel using pip, run:
 
 ```shell
-pip install git+https://github.com/juanluiscr27/shared-kernel.git@v8.0.0#egg=sharedkernel
+pip install git+https://github.com/juanluiscr27/shared-kernel.git@v9.0.0#egg=sharedkernel
 ```
 
 ## Usage

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ maintaining clean boundaries.
 ### Installation
 
 ```bash
-pip install git+https://github.com/juanluiscr27/shared-kernel.git@v8.0.0#egg=sharedkernel
+pip install git+https://github.com/juanluiscr27/shared-kernel.git@v9.0.0#egg=sharedkernel
 ```
 
 ### Basic Example: Value Objects

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sharedkernel"
-version = "8.0.0"
+version = "9.0.0"
 description = "Shared Kernel for clean architecture projects"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -428,7 +428,7 @@ wheels = [
 
 [[package]]
 name = "sharedkernel"
-version = "8.0.0"
+version = "9.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

Cuts release **9.0.0** for the changes landed since `v8.0.0`.

This is a **major** bump because both fixes since 8.0.0 change the public API contract in backward-incompatible ways:

- **`DomainEventHandler.process`** now takes a third `stream_id: UUID` argument; `EventBroker.publish` forwards the emitter stream_id so saga/inbox handlers can key their inbox on the source stream. Existing `process` overrides must be updated. (#131)
- **`Specification`** (ABC) gains two abstract methods `to_statement` / `to_filter` (already implemented by `QuerySpecification`); direct `Specification` subclasses must now implement both. (#130)

The internal `docs:` CLAUDE.md change is excluded from the changelog (tooling guidance, not library behavior).

## Changes

- `pyproject.toml` + `uv.lock`: version `8.0.0` → `9.0.0`
- `README.md`, `docs/index.md`: install ref `@v8.0.0` → `@v9.0.0`
- `CHANGELOG.md`: new `## 9.0.0 (2026-07-03)` section

## Verification

- `uv run tox -e py312` — 268 passed
- `uv run ruff check .` — passed
- `uv run mypy sharedkernel/` — no issues
- No stale `8.0.0` refs outside CHANGELOG history

## After merge

Tag the merge commit on `main`: `git tag v9.0.0 <merge-commit> && git push origin v9.0.0`.